### PR TITLE
feat: Linux カーネルローダーと boot_linux() を実装（Week 4）

### DIFF
--- a/examples/kernel_boot_test.rs
+++ b/examples/kernel_boot_test.rs
@@ -1,0 +1,90 @@
+//! カーネルブート機能のテスト
+//!
+//! 実際の Linux カーネルの代わりに、簡単なブートコードをテストする
+
+use hypervisor::boot::kernel::KernelImage;
+use hypervisor::devices::uart::Pl011Uart;
+use hypervisor::Hypervisor;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== カーネルブート機能のテスト ===\n");
+
+    // 1. ハイパーバイザーを作成
+    println!("[1] ハイパーバイザーを作成中...");
+    let mut hv = Hypervisor::new(0x4000_0000, 128 * 1024 * 1024)?;
+    println!("    ✓ ハイパーバイザー作成完了");
+
+    // 2. UART デバイスを登録
+    println!("\n[2] UART デバイスを登録中...");
+    let uart = Box::new(Pl011Uart::new(0x0900_0000));
+    hv.register_mmio_handler(uart);
+    println!("    ✓ UART デバイス登録完了");
+
+    // 3. 簡単なブートコードを作成
+    // UART に "Boot!" と出力して BRK で終了
+    println!("\n[3] ブートコードを作成中...");
+    let boot_code = vec![
+        // UART base address (0x09000000) を X1 に設定
+        0x01, 0x00, 0xa1, 0xd2, // movz x1, #0x9000, lsl #16
+        // 'B' (0x42) を X0 に設定して UART に書き込み
+        0x40, 0x08, 0x80, 0xd2, // movz x0, #0x42
+        0x20, 0x00, 0x00, 0xf9, // str x0, [x1]
+        // 'o' (0x6f) を X0 に設定して UART に書き込み
+        0xe0, 0x0d, 0x80, 0xd2, // movz x0, #0x6f
+        0x20, 0x00, 0x00, 0xf9, // str x0, [x1]
+        // 'o' (0x6f) を X0 に設定して UART に書き込み
+        0xe0, 0x0d, 0x80, 0xd2, // movz x0, #0x6f
+        0x20, 0x00, 0x00, 0xf9, // str x0, [x1]
+        // 't' (0x74) を X0 に設定して UART に書き込み
+        0x80, 0x0e, 0x80, 0xd2, // movz x0, #0x74
+        0x20, 0x00, 0x00, 0xf9, // str x0, [x1]
+        // '!' (0x21) を X0 に設定して UART に書き込み
+        0x20, 0x04, 0x80, 0xd2, // movz x0, #0x21
+        0x20, 0x00, 0x00, 0xf9, // str x0, [x1]
+        // '\n' (0x0a) を X0 に設定して UART に書き込み
+        0x40, 0x01, 0x80, 0xd2, // movz x0, #0x0a
+        0x20, 0x00, 0x00, 0xf9, // str x0, [x1]
+        // BRK #0 で終了
+        0x00, 0x00, 0x20, 0xd4, // brk #0
+    ];
+
+    let kernel = KernelImage::from_bytes(boot_code, Some(0x4008_0000));
+    println!(
+        "    ✓ ブートコード作成完了: {} bytes, entry_point=0x{:x}",
+        kernel.size(),
+        kernel.entry_point()
+    );
+
+    // 4. boot_linux() でカーネルをブート
+    println!("\n[4] カーネルをブート中...");
+    println!("    設定:");
+    println!("      - エントリーポイント: 0x{:x}", kernel.entry_point());
+    println!("      - Device Tree アドレス: 0x44000000");
+    println!("      - コマンドライン: console=ttyAMA0");
+    println!("\n    === カーネル出力 ===");
+
+    let result = hv.boot_linux(&kernel, "console=ttyAMA0", None)?;
+
+    println!("\n    === カーネル終了 ===");
+
+    // 5. 結果を検証
+    println!("\n[5] 結果を検証中...");
+    println!("    - Exit reason: {:?}", result.exit_reason);
+    println!("    - PC: 0x{:x}", result.pc);
+
+    if let Some(syndrome) = result.exception_syndrome {
+        let ec = (syndrome >> 26) & 0x3f;
+        println!("    - Exception Class (EC): 0x{:x}", ec);
+
+        if ec == 0x3c {
+            println!("    ✓ BRK 命令で正常終了");
+        } else {
+            println!("    ✗ 予期しない例外");
+        }
+    }
+
+    println!("\n✅ テスト完了");
+    println!("\n=== カーネルブート機能のテスト完了 ===");
+
+    Ok(())
+}

--- a/src/boot/kernel.rs
+++ b/src/boot/kernel.rs
@@ -1,0 +1,115 @@
+//! Linux カーネルローダー
+
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+/// Linux カーネルイメージ
+#[derive(Debug)]
+pub struct KernelImage {
+    /// カーネルバイナリデータ
+    data: Vec<u8>,
+    /// エントリーポイントアドレス（ARM64 標準: 0x40080000）
+    entry_point: u64,
+}
+
+impl KernelImage {
+    /// カーネルイメージをファイルから読み込む
+    ///
+    /// # Arguments
+    /// * `path` - カーネルイメージファイルのパス
+    ///
+    /// # Returns
+    /// カーネルイメージ
+    ///
+    /// # Example
+    /// ```no_run
+    /// use hypervisor::boot::kernel::KernelImage;
+    ///
+    /// let kernel = KernelImage::load("vmlinux").unwrap();
+    /// ```
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn Error>> {
+        let data = fs::read(path)?;
+
+        // ARM64 カーネルの標準エントリーポイント
+        // 参考: https://docs.kernel.org/arch/arm64/booting.html
+        let entry_point = 0x4008_0000;
+
+        Ok(Self { data, entry_point })
+    }
+
+    /// カーネルイメージをバイトデータから作成する
+    ///
+    /// # Arguments
+    /// * `data` - カーネルバイナリデータ
+    /// * `entry_point` - エントリーポイントアドレス（省略時: 0x40080000）
+    ///
+    /// # Example
+    /// ```
+    /// use hypervisor::boot::kernel::KernelImage;
+    ///
+    /// let data = vec![0x00, 0x00, 0x00, 0x14]; // b #0 (無限ループ)
+    /// let kernel = KernelImage::from_bytes(data, None);
+    /// ```
+    pub fn from_bytes(data: Vec<u8>, entry_point: Option<u64>) -> Self {
+        Self {
+            data,
+            entry_point: entry_point.unwrap_or(0x4008_0000),
+        }
+    }
+
+    /// エントリーポイントアドレスを取得する
+    pub fn entry_point(&self) -> u64 {
+        self.entry_point
+    }
+
+    /// カーネルイメージのサイズを取得する
+    pub fn size(&self) -> usize {
+        self.data.len()
+    }
+
+    /// カーネルイメージのデータへの参照を取得する
+    pub fn data(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kernel_image_from_bytes() {
+        let data = vec![0x00, 0x00, 0x00, 0x14]; // b #0
+        let kernel = KernelImage::from_bytes(data.clone(), None);
+
+        assert_eq!(kernel.entry_point(), 0x4008_0000);
+        assert_eq!(kernel.size(), 4);
+        assert_eq!(kernel.data(), &data);
+    }
+
+    #[test]
+    fn test_kernel_image_from_bytes_with_custom_entry_point() {
+        let data = vec![0x00, 0x00, 0x00, 0x14];
+        let custom_entry = 0x8000_0000;
+        let kernel = KernelImage::from_bytes(data, Some(custom_entry));
+
+        assert_eq!(kernel.entry_point(), custom_entry);
+    }
+
+    #[test]
+    fn test_kernel_image_empty_data() {
+        let kernel = KernelImage::from_bytes(vec![], None);
+        assert_eq!(kernel.size(), 0);
+        assert_eq!(kernel.data(), &[]);
+    }
+
+    #[test]
+    fn test_kernel_image_large_data() {
+        let data = vec![0x42; 1024 * 1024]; // 1MB
+        let kernel = KernelImage::from_bytes(data.clone(), None);
+
+        assert_eq!(kernel.size(), 1024 * 1024);
+        assert_eq!(kernel.data(), &data);
+    }
+}

--- a/src/boot/mod.rs
+++ b/src/boot/mod.rs
@@ -1,3 +1,4 @@
 //! Boot-related modules
 
 pub mod device_tree;
+pub mod kernel;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,69 @@
+//! 統合テスト
+//!
+//! Week 4 実装の機能テスト
+
+use hypervisor::boot::device_tree::{generate_device_tree, DeviceTreeConfig};
+use hypervisor::boot::kernel::KernelImage;
+
+#[test]
+fn test_kernel_image_creation() {
+    // 簡単なブートコード（BRK #0）
+    let boot_code = vec![0x00, 0x00, 0x20, 0xd4];
+    let kernel = KernelImage::from_bytes(boot_code.clone(), Some(0x4008_0000));
+
+    assert_eq!(kernel.entry_point(), 0x4008_0000);
+    assert_eq!(kernel.size(), 4);
+    assert_eq!(kernel.data(), &boot_code);
+}
+
+#[test]
+fn test_device_tree_with_kernel() {
+    // Device Tree を生成
+    let config = DeviceTreeConfig {
+        memory_base: 0x4000_0000,
+        memory_size: 128 * 1024 * 1024, // 128MB
+        uart_base: 0x0900_0000,
+        cmdline: "console=ttyAMA0 earlycon".to_string(),
+    };
+
+    let dtb = generate_device_tree(&config).unwrap();
+
+    // DTB が正しく生成されていることを確認
+    assert_eq!(dtb[0..4], [0xd0, 0x0d, 0xfe, 0xed]); // Magic number
+    assert!(dtb.len() > 100);
+}
+
+#[test]
+fn test_kernel_image_and_device_tree_integration() {
+    // 1. カーネルイメージを作成
+    let boot_code = vec![
+        0x00, 0x00, 0xa1, 0xd2, // movz x1, #0x9000, lsl #16
+        0x40, 0x08, 0x80, 0xd2, // movz x0, #0x42
+        0x20, 0x00, 0x00, 0xf9, // str x0, [x1]
+        0x00, 0x00, 0x20, 0xd4, // brk #0
+    ];
+    let kernel = KernelImage::from_bytes(boot_code, Some(0x4008_0000));
+
+    // 2. Device Tree を生成
+    let config = DeviceTreeConfig {
+        memory_base: 0x4000_0000,
+        memory_size: 128 * 1024 * 1024,
+        uart_base: 0x0900_0000,
+        cmdline: "console=ttyAMA0".to_string(),
+    };
+    let dtb = generate_device_tree(&config).unwrap();
+
+    // 3. カーネルと Device Tree が正しく生成されていることを確認
+    assert_eq!(kernel.entry_point(), 0x4008_0000);
+    assert_eq!(kernel.size(), 16);
+    assert_eq!(dtb[0..4], [0xd0, 0x0d, 0xfe, 0xed]);
+
+    // 4. メモリレイアウトを確認
+    // カーネル: 0x40080000
+    // DTB: 0x44000000
+    let kernel_addr = kernel.entry_point();
+    let dtb_addr = 0x4400_0000u64;
+
+    // カーネルと DTB が重ならないことを確認
+    assert!(kernel_addr + kernel.size() as u64 <= dtb_addr);
+}


### PR DESCRIPTION
## 概要

Week 4 の実装として、Linux カーネルローダーと `boot_linux()` メソッドを実装しました。

## 変更内容

### 1. カーネルローダー (`boot/kernel.rs`)
- `KernelImage` 構造体の実装
- `load()` - ファイルからカーネルイメージを読み込む
- `from_bytes()` - バイトデータからカーネルイメージを作成
- ユニットテスト 4 件

### 2. バイトレベルメモリ操作 (`lib.rs`)
- `write_byte()` - ゲストメモリにバイトデータを書き込む
- `read_byte()` - ゲストメモリからバイトデータを読み取る
- `Mapping` の 4-byte 制限を回避する実装

### 3. Linux ブート機能 (`lib.rs`)
- `boot_linux()` メソッドの実装
  - Device Tree 生成・メモリ配置
  - カーネルイメージのメモリ配置
  - ARM64 Linux ブート条件の設定
  - VM Exit ループ

### 4. テスト
- ユニットテスト: 15 件（すべて通過）
- 統合テスト: 3 件（すべて通過）
- 合計: 18 件

## 技術的詳細

### バイトレベルメモリ操作
`Mapping` は 4-byte 単位の read/write のみサポートするため、4-byte 単位で読み書きして部分更新を実装しました。

```rust
pub fn write_byte(&mut self, addr: u64, byte: u8) -> Result<(), Box<dyn std::error::Error>> {
    let aligned_addr = addr & !0x3;
    let offset = (addr & 0x3) as usize;
    let mut word = self.mem.read_dword(aligned_addr)?;
    let mut bytes = word.to_le_bytes();
    bytes[offset] = byte;
    word = u32::from_le_bytes(bytes);
    self.mem.write_dword(aligned_addr, word)?;
    Ok(())
}
```

### ARM64 Linux ブート条件
ARM64 Linux Booting Protocol に従って、以下のレジスタを設定しました：
- `X0`: Device Tree アドレス
- `X1-X3`: Reserved（0）
- `PC`: カーネルエントリーポイント（0x40080000）
- `CPSR`: 0x3c5（EL1h, DAIF masked）

参考: https://docs.kernel.org/arch/arm64/booting.html

## テスト結果

```bash
cargo test
```

- ユニットテスト: 15 passed
- 統合テスト: 3 passed
- 合計: 18 passed

すべてのテストが通過しています ✅

## 検証

```bash
cargo fmt    # ✅ フォーマットチェック通過
cargo clippy # ✅ lint チェック通過
cargo build  # ✅ ビルド成功
```

## 次のステップ

- Week 4 実装のブログ記事作成
- Phase 1 完了の振り返り
- Phase 2 の計画（VirtIO Block デバイス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>