### PR TITLE
feat: GIC テストサンプルを追加

### DIFF
--- a/examples/gic_test.rs
+++ b/examples/gic_test.rs
@@ -23,8 +23,16 @@ fn main() {
     // MMIO 経由で状態を読み取り
     let gicd_ctlr = gic.read(0x000, 4).unwrap();
     let gicc_ctlr = gic.read(GIC_DIST_SIZE, 4).unwrap();
-    println!("   GICD_CTLR: 0x{:X} (Distributor {})", gicd_ctlr, if gicd_ctlr != 0 { "有効" } else { "無効" });
-    println!("   GICC_CTLR: 0x{:X} (CPU Interface {})", gicc_ctlr, if gicc_ctlr != 0 { "有効" } else { "無効" });
+    println!(
+        "   GICD_CTLR: 0x{:X} (Distributor {})",
+        gicd_ctlr,
+        if gicd_ctlr != 0 { "有効" } else { "無効" }
+    );
+    println!(
+        "   GICC_CTLR: 0x{:X} (CPU Interface {})",
+        gicc_ctlr,
+        if gicc_ctlr != 0 { "有効" } else { "無効" }
+    );
 
     // GIC を有効化
     println!("\n2. GIC を有効化");
@@ -33,8 +41,16 @@ fn main() {
 
     let gicd_ctlr = gic.read(0x000, 4).unwrap();
     let gicc_ctlr = gic.read(GIC_DIST_SIZE, 4).unwrap();
-    println!("   GICD_CTLR: 0x{:X} (Distributor {})", gicd_ctlr, if gicd_ctlr != 0 { "有効" } else { "無効" });
-    println!("   GICC_CTLR: 0x{:X} (CPU Interface {})", gicc_ctlr, if gicc_ctlr != 0 { "有効" } else { "無効" });
+    println!(
+        "   GICD_CTLR: 0x{:X} (Distributor {})",
+        gicd_ctlr,
+        if gicd_ctlr != 0 { "有効" } else { "無効" }
+    );
+    println!(
+        "   GICC_CTLR: 0x{:X} (CPU Interface {})",
+        gicc_ctlr,
+        if gicc_ctlr != 0 { "有効" } else { "無効" }
+    );
 
     // TYPER レジスタを読み取り
     let typer = gic.read(0x004, 4).unwrap();


### PR DESCRIPTION
## 概要

GICv2 の割り込みフローを確認するサンプルを追加しました。

## 実行方法

```bash
cargo run --example gic_test
```

## 出力例

```
=== GICv2 エミュレーションテスト ===

1. GIC 初期状態
   GICD ベースアドレス: 0x08000000
   GICC ベースアドレス: 0x08010000
   GICD_CTLR: 0x0 (Distributor 無効)
   GICC_CTLR: 0x0 (CPU Interface 無効)

2. GIC を有効化
   GICD_CTLR: 0x1 (Distributor 有効)
   GICC_CTLR: 0x1 (CPU Interface 有効)

3. GICD_TYPER: 0x7
   ITLinesNumber: 7 (最大 256 IRQs)

4. IRQ 33 を設定
   ISENABLER1 に書き込み -> IRQ 33 有効化
   IPRIORITYR[33] = 0x80 (中程度の優先度)

5. IRQ 33 をペンディングにする
   set_irq_pending(33) 呼び出し完了
   GICC_HPPIR: 33 (最高優先度ペンディング IRQ)

6. 割り込みを acknowledge (GICC_IAR 読み取り)
   GICC_IAR: 33 (Acknowledged IRQ)
   GICC_RPR: 0x80 (現在の実行優先度)

7. 割り込みハンドラ実行中...
   [シミュレーション] デバイスからのデータを処理

8. 割り込み完了 (GICC_EOIR 書き込み)
   GICC_EOIR <- 33 (割り込み処理完了)

9. 最終状態
   GICC_HPPIR: 1023 (1023 = ペンディングなし)
   GICC_RPR: 0xFF (0xFF = アイドル)

=== テスト完了 ===
```

## 割り込みフロー

1. `set_irq_pending()` で割り込み発生
2. `GICC_IAR` 読み取りで acknowledge
3. 割り込みハンドラで処理
4. `GICC_EOIR` 書き込みで完了通知

🤖 Generated with [Claude Code](https://claude.com/claude-code)