### PR TITLE
feat: ARM Generic Timer エミュレーション実装 (Phase 3 Week 2)

### DIFF
--- a/examples/timer_test.rs
+++ b/examples/timer_test.rs
@@ -1,0 +1,156 @@
+//! ARM Generic Timer のテスト
+//!
+//! タイマーの動作とシステムレジスタアクセスを確認します。
+//!
+//! 実行方法:
+//! ```bash
+//! cargo run --example timer_test
+//! ```
+
+use hypervisor::devices::timer::{Timer, TimerReg, PHYS_TIMER_IRQ, TIMER_FREQ, VIRT_TIMER_IRQ};
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    println!("=== ARM Generic Timer テスト ===\n");
+
+    // タイマーを作成
+    let mut timer = Timer::new();
+
+    println!("1. タイマー初期状態");
+    println!(
+        "   周波数: {} Hz ({:.2} MHz)",
+        TIMER_FREQ,
+        TIMER_FREQ as f64 / 1_000_000.0
+    );
+    println!("   物理タイマー IRQ: {}", PHYS_TIMER_IRQ);
+    println!("   仮想タイマー IRQ: {}", VIRT_TIMER_IRQ);
+
+    // カウンタを読み取り
+    let phys_cnt = timer.read_sysreg(TimerReg::CNTPCT_EL0).unwrap();
+    let virt_cnt = timer.read_sysreg(TimerReg::CNTVCT_EL0).unwrap();
+    println!("\n2. カウンタ値");
+    println!("   CNTPCT_EL0 (物理): {}", phys_cnt);
+    println!("   CNTVCT_EL0 (仮想): {}", virt_cnt);
+
+    // 少し待ってカウンタが増加することを確認
+    println!("\n3. 100ms 待機してカウンタ増加を確認");
+    thread::sleep(Duration::from_millis(100));
+    let phys_cnt_after = timer.read_sysreg(TimerReg::CNTPCT_EL0).unwrap();
+    let expected_increase = TIMER_FREQ / 10; // 100ms = 1/10秒
+    println!("   CNTPCT_EL0: {} -> {}", phys_cnt, phys_cnt_after);
+    println!(
+        "   増加量: {} (期待値: 約 {})",
+        phys_cnt_after - phys_cnt,
+        expected_increase
+    );
+
+    // 物理タイマーを設定
+    println!("\n4. 物理タイマーを設定");
+
+    // 現在のカウンタ値を取得
+    let current = timer.get_phys_counter();
+
+    // 50ms 後にタイマーを発火させる
+    let fire_after_ticks = TIMER_FREQ / 20; // 50ms
+    let cval = current + fire_after_ticks;
+
+    // CVAL を設定
+    timer.write_sysreg(TimerReg::CNTP_CVAL_EL0, cval).unwrap();
+    println!(
+        "   CNTP_CVAL_EL0 <- {} (現在 {} + {})",
+        cval, current, fire_after_ticks
+    );
+
+    // タイマーを有効化 (ENABLE=1, IMASK=0)
+    timer.write_sysreg(TimerReg::CNTP_CTL_EL0, 1).unwrap();
+    println!("   CNTP_CTL_EL0 <- 1 (タイマー有効化)");
+
+    // タイマー状態を確認
+    let ctl = timer.read_sysreg(TimerReg::CNTP_CTL_EL0).unwrap();
+    println!(
+        "   CNTP_CTL_EL0 = 0x{:X} (ENABLE={}, IMASK={}, ISTATUS={})",
+        ctl,
+        (ctl >> 0) & 1,
+        (ctl >> 1) & 1,
+        (ctl >> 2) & 1
+    );
+
+    // 次のイベントまでの時間を確認
+    if let Some(nanos) = timer.time_until_next_event() {
+        println!(
+            "   次のタイマーイベントまで: {:.2} ms",
+            nanos as f64 / 1_000_000.0
+        );
+    }
+
+    // 割り込みがペンディングしていないことを確認
+    println!("\n5. 割り込み状態を確認（発火前）");
+    let pending = timer.get_pending_irqs();
+    println!("   ペンディング IRQ: {:?}", pending);
+    println!(
+        "   物理タイマーペンディング: {}",
+        timer.phys_timer_pending()
+    );
+
+    // 60ms 待機してタイマーを発火させる
+    println!("\n6. 60ms 待機してタイマー発火を確認");
+    thread::sleep(Duration::from_millis(60));
+
+    let ctl_after = timer.read_sysreg(TimerReg::CNTP_CTL_EL0).unwrap();
+    println!(
+        "   CNTP_CTL_EL0 = 0x{:X} (ENABLE={}, IMASK={}, ISTATUS={})",
+        ctl_after,
+        (ctl_after >> 0) & 1,
+        (ctl_after >> 1) & 1,
+        (ctl_after >> 2) & 1
+    );
+
+    let pending_after = timer.get_pending_irqs();
+    println!("   ペンディング IRQ: {:?}", pending_after);
+    println!(
+        "   物理タイマーペンディング: {}",
+        timer.phys_timer_pending()
+    );
+
+    // 仮想オフセットのデモ
+    println!("\n7. 仮想オフセット (CNTVOFF_EL2) のデモ");
+    let offset = TIMER_FREQ; // 1秒分のオフセット
+    timer.set_virt_offset(offset);
+    println!("   CNTVOFF_EL2 <- {} (1秒分のオフセット)", offset);
+
+    let phys = timer.get_phys_counter();
+    let virt = timer.get_virt_counter();
+    println!("   物理カウンタ: {}", phys);
+    println!("   仮想カウンタ: {} (= 物理 - オフセット)", virt);
+    println!("   差分: {} (= オフセット値)", phys.saturating_sub(virt));
+
+    // TVAL レジスタのデモ
+    println!("\n8. TVAL レジスタのデモ");
+    let tval_set = TIMER_FREQ / 2; // 500ms
+    timer
+        .write_sysreg(TimerReg::CNTP_TVAL_EL0, tval_set)
+        .unwrap();
+    println!("   CNTP_TVAL_EL0 <- {} (500ms 分)", tval_set);
+
+    let tval_read = timer.read_sysreg(TimerReg::CNTP_TVAL_EL0).unwrap();
+    let cval_read = timer.read_sysreg(TimerReg::CNTP_CVAL_EL0).unwrap();
+    println!("   CNTP_TVAL_EL0 = {} (カウンタダウン値)", tval_read);
+    println!("   CNTP_CVAL_EL0 = {} (絶対比較値)", cval_read);
+
+    // タイマー無効化
+    println!("\n9. タイマー無効化");
+    timer.write_sysreg(TimerReg::CNTP_CTL_EL0, 0).unwrap();
+    println!("   CNTP_CTL_EL0 <- 0 (タイマー無効化)");
+
+    let pending_final = timer.get_pending_irqs();
+    println!("   ペンディング IRQ: {:?}", pending_final);
+
+    println!("\n=== テスト完了 ===");
+    println!("\nARM Generic Timer の動作:");
+    println!("  1. CNTPCT_EL0/CNTVCT_EL0 で現在のカウンタ値を取得");
+    println!("  2. CNTP_CVAL_EL0 で絶対比較値を設定");
+    println!("  3. CNTP_TVAL_EL0 で相対タイマー値を設定");
+    println!("  4. CNTP_CTL_EL0 でタイマーを有効化/無効化");
+    println!("  5. カウンタ >= CVAL になると ISTATUS=1 で割り込み発生");
+}

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,5 +1,6 @@
 //! Device emulation modules
 
 pub mod gic;
+pub mod timer;
 pub mod uart;
 pub mod virtio;

--- a/src/devices/timer.rs
+++ b/src/devices/timer.rs
@@ -1,0 +1,457 @@
+//! ARM Generic Timer エミュレーション
+//!
+//! ARM アーキテクチャの Generic Timer を提供します。
+//! - 物理タイマー (EL1 Physical Timer)
+//! - 仮想タイマー (EL1 Virtual Timer)
+//!
+//! Linux カーネルは起動時にタイマーを使用してスケジューリングを行います。
+
+use std::error::Error;
+use std::time::Instant;
+
+/// タイマー周波数 (Hz)
+/// ARM では通常 1GHz または 24MHz など
+pub const TIMER_FREQ: u64 = 62_500_000; // 62.5 MHz (QEMU virt のデフォルト)
+
+/// 物理タイマー IRQ (PPI)
+pub const PHYS_TIMER_IRQ: u32 = 30;
+/// 仮想タイマー IRQ (PPI)
+pub const VIRT_TIMER_IRQ: u32 = 27;
+/// ハイパーバイザータイマー IRQ (PPI)
+pub const HYP_TIMER_IRQ: u32 = 26;
+/// セキュア物理タイマー IRQ (PPI)
+pub const SEC_TIMER_IRQ: u32 = 29;
+
+/// タイマー制御レジスタのビット
+mod ctl_bits {
+    /// タイマー有効
+    pub const ENABLE: u64 = 1 << 0;
+    /// 割り込みマスク
+    pub const IMASK: u64 = 1 << 1;
+    /// 割り込み状態 (読み取り専用)
+    pub const ISTATUS: u64 = 1 << 2;
+}
+
+/// 個別タイマーの状態
+#[derive(Debug, Clone)]
+pub struct TimerState {
+    /// 制御レジスタ (CTL)
+    ctl: u64,
+    /// 比較値レジスタ (CVAL)
+    cval: u64,
+}
+
+impl Default for TimerState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TimerState {
+    /// 新しいタイマー状態を作成
+    pub fn new() -> Self {
+        Self { ctl: 0, cval: 0 }
+    }
+
+    /// タイマーが有効かどうか
+    pub fn is_enabled(&self) -> bool {
+        (self.ctl & ctl_bits::ENABLE) != 0
+    }
+
+    /// 割り込みがマスクされているか
+    pub fn is_masked(&self) -> bool {
+        (self.ctl & ctl_bits::IMASK) != 0
+    }
+
+    /// 割り込みがアサートされているか (カウンタ >= CVAL)
+    pub fn is_asserted(&self, counter: u64) -> bool {
+        self.is_enabled() && counter >= self.cval
+    }
+
+    /// 割り込みをトリガーすべきか
+    pub fn should_interrupt(&self, counter: u64) -> bool {
+        self.is_asserted(counter) && !self.is_masked()
+    }
+
+    /// CTL レジスタを読み取り
+    pub fn read_ctl(&self, counter: u64) -> u64 {
+        let mut value = self.ctl & (ctl_bits::ENABLE | ctl_bits::IMASK);
+        if self.is_asserted(counter) {
+            value |= ctl_bits::ISTATUS;
+        }
+        value
+    }
+
+    /// CTL レジスタに書き込み
+    pub fn write_ctl(&mut self, value: u64) {
+        // ISTATUS は読み取り専用なので無視
+        self.ctl = value & (ctl_bits::ENABLE | ctl_bits::IMASK);
+    }
+
+    /// TVAL レジスタを読み取り (カウンタからの相対値)
+    pub fn read_tval(&self, counter: u64) -> u64 {
+        // TVAL = CVAL - Counter (符号付き)
+        self.cval.wrapping_sub(counter)
+    }
+
+    /// TVAL レジスタに書き込み (カウンタからの相対値)
+    pub fn write_tval(&mut self, value: u64, counter: u64) {
+        // CVAL = Counter + TVAL
+        self.cval = counter.wrapping_add(value);
+    }
+
+    /// CVAL レジスタを読み取り
+    pub fn read_cval(&self) -> u64 {
+        self.cval
+    }
+
+    /// CVAL レジスタに書き込み
+    pub fn write_cval(&mut self, value: u64) {
+        self.cval = value;
+    }
+}
+
+/// ARM Generic Timer
+#[derive(Debug)]
+pub struct Timer {
+    /// 開始時刻 (カウンタ計算用)
+    start_time: Instant,
+    /// 物理タイマー
+    pub phys_timer: TimerState,
+    /// 仮想タイマー
+    pub virt_timer: TimerState,
+    /// 仮想オフセット (CNTVOFF_EL2)
+    virt_offset: u64,
+}
+
+impl Default for Timer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Timer {
+    /// 新しいタイマーを作成
+    pub fn new() -> Self {
+        Self {
+            start_time: Instant::now(),
+            phys_timer: TimerState::new(),
+            virt_timer: TimerState::new(),
+            virt_offset: 0,
+        }
+    }
+
+    /// 物理カウンタ値を取得 (CNTPCT_EL0)
+    pub fn get_phys_counter(&self) -> u64 {
+        let elapsed = self.start_time.elapsed();
+        let nanos = elapsed.as_nanos() as u64;
+        // カウンタ = 経過時間 * 周波数 / 10^9
+        nanos * TIMER_FREQ / 1_000_000_000
+    }
+
+    /// 仮想カウンタ値を取得 (CNTVCT_EL0)
+    pub fn get_virt_counter(&self) -> u64 {
+        self.get_phys_counter().wrapping_sub(self.virt_offset)
+    }
+
+    /// タイマー周波数を取得 (CNTFRQ_EL0)
+    pub fn get_frequency(&self) -> u64 {
+        TIMER_FREQ
+    }
+
+    /// 仮想オフセットを設定 (CNTVOFF_EL2)
+    pub fn set_virt_offset(&mut self, offset: u64) {
+        self.virt_offset = offset;
+    }
+
+    /// 仮想オフセットを取得
+    pub fn get_virt_offset(&self) -> u64 {
+        self.virt_offset
+    }
+
+    /// 物理タイマーが割り込みをトリガーすべきか
+    pub fn phys_timer_pending(&self) -> bool {
+        self.phys_timer.should_interrupt(self.get_phys_counter())
+    }
+
+    /// 仮想タイマーが割り込みをトリガーすべきか
+    pub fn virt_timer_pending(&self) -> bool {
+        self.virt_timer.should_interrupt(self.get_virt_counter())
+    }
+
+    /// ペンディング中のタイマー IRQ を取得
+    pub fn get_pending_irqs(&self) -> Vec<u32> {
+        let mut irqs = Vec::new();
+        if self.phys_timer_pending() {
+            irqs.push(PHYS_TIMER_IRQ);
+        }
+        if self.virt_timer_pending() {
+            irqs.push(VIRT_TIMER_IRQ);
+        }
+        irqs
+    }
+
+    /// 次のタイマーイベントまでの時間 (ナノ秒)
+    pub fn time_until_next_event(&self) -> Option<u64> {
+        let phys_counter = self.get_phys_counter();
+        let virt_counter = self.get_virt_counter();
+
+        let mut min_ticks: Option<u64> = None;
+
+        // 物理タイマー
+        if self.phys_timer.is_enabled()
+            && !self.phys_timer.is_masked()
+            && self.phys_timer.cval > phys_counter
+        {
+            let ticks = self.phys_timer.cval - phys_counter;
+            min_ticks = Some(min_ticks.map_or(ticks, |m| m.min(ticks)));
+        }
+
+        // 仮想タイマー
+        if self.virt_timer.is_enabled()
+            && !self.virt_timer.is_masked()
+            && self.virt_timer.cval > virt_counter
+        {
+            let ticks = self.virt_timer.cval - virt_counter;
+            min_ticks = Some(min_ticks.map_or(ticks, |m| m.min(ticks)));
+        }
+
+        // ティックをナノ秒に変換
+        min_ticks.map(|ticks| ticks * 1_000_000_000 / TIMER_FREQ)
+    }
+
+    /// システムレジスタを読み取り
+    pub fn read_sysreg(&self, reg: TimerReg) -> Result<u64, Box<dyn Error>> {
+        let phys_counter = self.get_phys_counter();
+        let virt_counter = self.get_virt_counter();
+
+        let value = match reg {
+            TimerReg::CNTFRQ_EL0 => self.get_frequency(),
+            TimerReg::CNTPCT_EL0 => phys_counter,
+            TimerReg::CNTVCT_EL0 => virt_counter,
+            TimerReg::CNTP_CTL_EL0 => self.phys_timer.read_ctl(phys_counter),
+            TimerReg::CNTP_CVAL_EL0 => self.phys_timer.read_cval(),
+            TimerReg::CNTP_TVAL_EL0 => self.phys_timer.read_tval(phys_counter),
+            TimerReg::CNTV_CTL_EL0 => self.virt_timer.read_ctl(virt_counter),
+            TimerReg::CNTV_CVAL_EL0 => self.virt_timer.read_cval(),
+            TimerReg::CNTV_TVAL_EL0 => self.virt_timer.read_tval(virt_counter),
+            TimerReg::CNTVOFF_EL2 => self.virt_offset,
+        };
+        Ok(value)
+    }
+
+    /// システムレジスタに書き込み
+    pub fn write_sysreg(&mut self, reg: TimerReg, value: u64) -> Result<(), Box<dyn Error>> {
+        let phys_counter = self.get_phys_counter();
+        let virt_counter = self.get_virt_counter();
+
+        match reg {
+            TimerReg::CNTFRQ_EL0 => {
+                // 周波数は読み取り専用として扱う
+            }
+            TimerReg::CNTPCT_EL0 | TimerReg::CNTVCT_EL0 => {
+                // カウンタは読み取り専用
+            }
+            TimerReg::CNTP_CTL_EL0 => self.phys_timer.write_ctl(value),
+            TimerReg::CNTP_CVAL_EL0 => self.phys_timer.write_cval(value),
+            TimerReg::CNTP_TVAL_EL0 => self.phys_timer.write_tval(value, phys_counter),
+            TimerReg::CNTV_CTL_EL0 => self.virt_timer.write_ctl(value),
+            TimerReg::CNTV_CVAL_EL0 => self.virt_timer.write_cval(value),
+            TimerReg::CNTV_TVAL_EL0 => self.virt_timer.write_tval(value, virt_counter),
+            TimerReg::CNTVOFF_EL2 => self.virt_offset = value,
+        }
+        Ok(())
+    }
+}
+
+/// タイマーシステムレジスタ
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(non_camel_case_types)]
+pub enum TimerReg {
+    /// カウンタ周波数
+    CNTFRQ_EL0,
+    /// 物理カウンタ
+    CNTPCT_EL0,
+    /// 仮想カウンタ
+    CNTVCT_EL0,
+    /// 物理タイマー制御
+    CNTP_CTL_EL0,
+    /// 物理タイマー比較値
+    CNTP_CVAL_EL0,
+    /// 物理タイマータイマー値
+    CNTP_TVAL_EL0,
+    /// 仮想タイマー制御
+    CNTV_CTL_EL0,
+    /// 仮想タイマー比較値
+    CNTV_CVAL_EL0,
+    /// 仮想タイマータイマー値
+    CNTV_TVAL_EL0,
+    /// 仮想オフセット
+    CNTVOFF_EL2,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn timer_new_の初期状態を確認() {
+        let timer = Timer::new();
+        assert!(!timer.phys_timer.is_enabled());
+        assert!(!timer.virt_timer.is_enabled());
+        assert_eq!(timer.virt_offset, 0);
+    }
+
+    #[test]
+    fn get_frequency_は正しい周波数を返す() {
+        let timer = Timer::new();
+        assert_eq!(timer.get_frequency(), TIMER_FREQ);
+    }
+
+    #[test]
+    fn get_phys_counter_は増加する() {
+        let timer = Timer::new();
+        let c1 = timer.get_phys_counter();
+        thread::sleep(Duration::from_millis(10));
+        let c2 = timer.get_phys_counter();
+        assert!(c2 > c1);
+    }
+
+    #[test]
+    fn get_virt_counter_はオフセットを反映する() {
+        let mut timer = Timer::new();
+        let phys = timer.get_phys_counter();
+        timer.set_virt_offset(1000);
+        let virt = timer.get_virt_counter();
+        // virt = phys - offset なので virt < phys
+        assert!(virt < phys || phys < 1000);
+    }
+
+    #[test]
+    fn timer_state_ctl_の読み書き() {
+        let mut state = TimerState::new();
+        state.write_ctl(ctl_bits::ENABLE | ctl_bits::IMASK);
+        assert!(state.is_enabled());
+        assert!(state.is_masked());
+    }
+
+    #[test]
+    fn timer_state_cval_の読み書き() {
+        let mut state = TimerState::new();
+        state.write_cval(12345);
+        assert_eq!(state.read_cval(), 12345);
+    }
+
+    #[test]
+    fn timer_state_tval_の読み書き() {
+        let mut state = TimerState::new();
+        let counter = 1000u64;
+        state.write_tval(500, counter);
+        // CVAL = counter + tval = 1000 + 500 = 1500
+        assert_eq!(state.read_cval(), 1500);
+        // TVAL = CVAL - counter = 1500 - 1000 = 500
+        assert_eq!(state.read_tval(counter), 500);
+    }
+
+    #[test]
+    fn timer_state_is_asserted_はカウンタがcvalを超えるとtrueを返す() {
+        let mut state = TimerState::new();
+        state.write_ctl(ctl_bits::ENABLE);
+        state.write_cval(100);
+
+        assert!(!state.is_asserted(50));
+        assert!(state.is_asserted(100));
+        assert!(state.is_asserted(150));
+    }
+
+    #[test]
+    fn timer_state_should_interrupt_はマスク時にfalseを返す() {
+        let mut state = TimerState::new();
+        state.write_ctl(ctl_bits::ENABLE | ctl_bits::IMASK);
+        state.write_cval(100);
+
+        // アサートされているがマスクされている
+        assert!(state.is_asserted(150));
+        assert!(!state.should_interrupt(150));
+    }
+
+    #[test]
+    fn timer_state_read_ctl_はistatusを含む() {
+        let mut state = TimerState::new();
+        state.write_ctl(ctl_bits::ENABLE);
+        state.write_cval(100);
+
+        // カウンタ < CVAL: ISTATUS = 0
+        let ctl = state.read_ctl(50);
+        assert_eq!(ctl & ctl_bits::ISTATUS, 0);
+
+        // カウンタ >= CVAL: ISTATUS = 1
+        let ctl = state.read_ctl(150);
+        assert_ne!(ctl & ctl_bits::ISTATUS, 0);
+    }
+
+    #[test]
+    fn phys_timer_pending_は正しく判定する() {
+        let mut timer = Timer::new();
+        let counter = timer.get_phys_counter();
+
+        // タイマーを有効化して過去の値を設定
+        timer.phys_timer.write_ctl(ctl_bits::ENABLE);
+        timer.phys_timer.write_cval(counter.saturating_sub(100));
+
+        assert!(timer.phys_timer_pending());
+    }
+
+    #[test]
+    fn read_sysreg_でcntfrq_el0を読める() {
+        let timer = Timer::new();
+        let freq = timer.read_sysreg(TimerReg::CNTFRQ_EL0).unwrap();
+        assert_eq!(freq, TIMER_FREQ);
+    }
+
+    #[test]
+    fn write_sysreg_でcntp_ctl_el0を書ける() {
+        let mut timer = Timer::new();
+        timer
+            .write_sysreg(TimerReg::CNTP_CTL_EL0, ctl_bits::ENABLE)
+            .unwrap();
+        assert!(timer.phys_timer.is_enabled());
+    }
+
+    #[test]
+    fn time_until_next_event_は有効なタイマーがない場合noneを返す() {
+        let timer = Timer::new();
+        assert!(timer.time_until_next_event().is_none());
+    }
+
+    #[test]
+    fn time_until_next_event_は次のイベントまでの時間を返す() {
+        let mut timer = Timer::new();
+        let counter = timer.get_phys_counter();
+
+        timer.phys_timer.write_ctl(ctl_bits::ENABLE);
+        // 1秒後に設定
+        timer.phys_timer.write_cval(counter + TIMER_FREQ);
+
+        let time = timer.time_until_next_event();
+        assert!(time.is_some());
+        // おおよそ1秒 (1_000_000_000 ナノ秒) 前後
+        let nanos = time.unwrap();
+        assert!(nanos > 900_000_000 && nanos < 1_100_000_000);
+    }
+
+    #[test]
+    fn get_pending_irqs_はペンディング中のirqを返す() {
+        let mut timer = Timer::new();
+        let counter = timer.get_phys_counter();
+
+        // 物理タイマーを過去に設定
+        timer.phys_timer.write_ctl(ctl_bits::ENABLE);
+        timer.phys_timer.write_cval(counter.saturating_sub(100));
+
+        let irqs = timer.get_pending_irqs();
+        assert!(irqs.contains(&PHYS_TIMER_IRQ));
+    }
+}


### PR DESCRIPTION
## 概要

ARM アーキテクチャの Generic Timer をエミュレートする機能を追加しました。Linux カーネルは起動時にタイマーを使用してスケジューリングを行います。

## 変更内容

### 新規ファイル
- `src/devices/timer.rs`: ARM Generic Timer 実装
- `examples/timer_test.rs`: タイマー動作確認サンプル

### 主な機能

#### TimerState 構造体
個別タイマー（物理/仮想）の状態を管理します。
- CTL レジスタ: ENABLE, IMASK, ISTATUS ビット
- CVAL レジスタ: 絶対比較値
- TVAL レジスタ: 相対タイマー値

#### Timer 構造体
物理タイマーと仮想タイマーを統合管理します。
- `get_phys_counter()`: 物理カウンタ値取得
- `get_virt_counter()`: 仮想カウンタ値取得
- `phys_timer_pending()`: 物理タイマー割り込みペンディング確認
- `virt_timer_pending()`: 仮想タイマー割り込みペンディング確認
- `time_until_next_event()`: 次のタイマーイベントまでの時間

#### システムレジスタ
- CNTFRQ_EL0: タイマー周波数（62.5 MHz）
- CNTPCT_EL0: 物理カウンタ
- CNTVCT_EL0: 仮想カウンタ
- CNTP_CTL_EL0: 物理タイマー制御
- CNTP_CVAL_EL0: 物理タイマー比較値
- CNTP_TVAL_EL0: 物理タイマー値
- CNTV_CTL_EL0: 仮想タイマー制御
- CNTV_CVAL_EL0: 仮想タイマー比較値
- CNTV_TVAL_EL0: 仮想タイマー値
- CNTVOFF_EL2: 仮想オフセット

## テスト

```bash
# ユニットテスト（16 件すべてパス）
cargo test devices::timer

# サンプル実行
cargo run --example timer_test
```

### テスト結果
```
running 16 tests
test devices::timer::tests::get_frequency_は正しい周波数を返す ... ok
test devices::timer::tests::get_pending_irqs_はペンディング中のirqを返す ... ok
test devices::timer::tests::phys_timer_pending_は正しく判定する ... ok
...
test result: ok. 16 passed; 0 failed; 0 ignored
```

## 検証
- [x] cargo test（全 69 テストパス）
- [x] cargo clippy（警告なし）
- [x] cargo fmt（適用済み）
- [x] サンプル動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)