### PR TITLE
feat: Phase 4 Week 3-6 WFI/PSCI, UART 完全実装, HVC バグ修正

### DIFF
--- a/docs/linux-kernel-build.md
+++ b/docs/linux-kernel-build.md
@@ -1,0 +1,152 @@
+# Linux カーネルビルド手順
+
+macOS で ARM64 Linux カーネルをクロスコンパイルする手順。
+
+## 前提条件
+
+### クロスコンパイラのインストール
+
+```bash
+# Homebrew で ARM64 クロスコンパイラをインストール
+brew install aarch64-linux-gnu-binutils
+brew install aarch64-linux-gnu-gcc
+
+# または LLVM/Clang を使用 (推奨)
+brew install llvm
+export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+```
+
+## カーネルソースの取得
+
+```bash
+# Linux カーネル v6.x をダウンロード
+git clone --depth 1 --branch v6.6 https://github.com/torvalds/linux.git linux-6.6
+cd linux-6.6
+```
+
+## 最小構成の defconfig
+
+```bash
+# ARM64 向け最小構成を作成
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- defconfig
+
+# または LLVM を使用
+make ARCH=arm64 LLVM=1 defconfig
+```
+
+### 推奨カーネル設定
+
+```bash
+# menuconfig で設定を調整
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- menuconfig
+```
+
+必要な設定:
+- `CONFIG_SERIAL_AMBA_PL011=y` - PL011 UART ドライバ
+- `CONFIG_SERIAL_AMBA_PL011_CONSOLE=y` - PL011 コンソール
+- `CONFIG_ARM_GIC=y` - GIC 割り込みコントローラ
+- `CONFIG_ARM_ARCH_TIMER=y` - ARM Generic Timer
+- `CONFIG_EARLY_PRINTK=y` - early printk
+- `CONFIG_CMDLINE="console=ttyAMA0 earlycon"` - デフォルトコマンドライン
+
+無効化推奨:
+- `CONFIG_MODULES=n` - モジュールサポート（不要）
+- `CONFIG_NETWORK=n` - ネットワーク（不要）
+- `CONFIG_BLOCK=n` - ブロックデバイス（初期テストでは不要）
+
+## カーネルビルド
+
+```bash
+# GNU ツールチェインでビルド
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image -j$(nproc)
+
+# または LLVM でビルド
+make ARCH=arm64 LLVM=1 Image -j$(nproc)
+```
+
+生成されるファイル:
+- `arch/arm64/boot/Image` - 非圧縮カーネルイメージ
+
+## Docker を使用したビルド (推奨)
+
+macOS でクロスコンパイラの設定が困難な場合、Docker を使用すると簡単です。
+
+```bash
+# Dockerfile
+cat > Dockerfile.linux-build << 'EOF'
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc-aarch64-linux-gnu \
+    binutils-aarch64-linux-gnu \
+    bison \
+    flex \
+    libncurses-dev \
+    libssl-dev \
+    libelf-dev \
+    bc \
+    git
+WORKDIR /linux
+EOF
+
+# ビルド
+docker build -t linux-build -f Dockerfile.linux-build .
+
+# カーネルソースをマウントしてビルド
+docker run -v $(pwd)/linux-6.6:/linux linux-build \
+    make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- defconfig Image -j$(nproc)
+```
+
+## ハイパーバイザーでの起動
+
+```rust
+use hypervisor::{Hypervisor, boot::kernel::KernelImage};
+
+// カーネルイメージを読み込み
+let kernel_data = std::fs::read("linux-6.6/arch/arm64/boot/Image")?;
+let kernel = KernelImage::from_bytes(kernel_data, Some(0x4008_0000));
+
+// ハイパーバイザーを作成
+let mut hv = Hypervisor::new(0x4000_0000, 128 * 1024 * 1024)?;
+
+// UART デバイスを登録
+let uart = hypervisor::devices::uart::Pl011Uart::new(0x0900_0000);
+hv.register_mmio_handler(Box::new(uart));
+
+// カーネルを起動
+let result = hv.boot_linux(&kernel, "console=ttyAMA0 earlycon", None)?;
+```
+
+## トラブルシューティング
+
+### UART 出力がない場合
+
+1. Device Tree の UART ノードが正しいか確認
+2. カーネルコマンドラインに `earlycon` が含まれているか確認
+3. UART ベースアドレス (0x0900_0000) が正しいか確認
+
+### カーネルがハングする場合
+
+1. `EC` コード（例外クラス）を確認
+2. 未対応のシステムレジスタアクセスがないか確認
+3. WFI/WFE が正しくハンドリングされているか確認
+
+### VFS マウント失敗で panic
+
+これは正常な動作です。initramfs がない場合、カーネルは VFS マウントに失敗して panic します。
+earlycon 出力まで到達していれば、ハイパーバイザーは正常に動作しています。
+
+## 期待される出力
+
+正常に起動した場合、UART に以下のような出力が表示されます。
+
+```
+Booting Linux on physical CPU 0x0
+Linux version 6.6.0 ...
+earlycon: pl011 at MMIO 0x09000000 ...
+Machine: linux,dummy-virt
+...
+Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)
+```
+
+"Kernel panic - VFS" は initramfs がないことによる正常な終了です。

--- a/src/devices/uart.rs
+++ b/src/devices/uart.rs
@@ -1,23 +1,176 @@
 //! PL011 UART device emulation
+//!
+//! ARM PL011 UART コントローラーのエミュレーション。
+//! Linux カーネルの earlycon および標準 UART ドライバに対応。
 
 use crate::mmio::MmioHandler;
 use std::error::Error;
 use std::io::{self, Write};
 
 /// PL011 UART register offsets
-const UART_DR: u64 = 0x00; // Data Register
-const UART_FR: u64 = 0x18; // Flag Register
+mod regs {
+    /// Data Register (R/W)
+    pub const DR: u64 = 0x00;
+    /// Receive Status / Error Clear (R/W)
+    pub const RSR_ECR: u64 = 0x04;
+    /// Flag Register (RO)
+    pub const FR: u64 = 0x18;
+    /// IrDA Low-Power Counter (R/W) - not implemented
+    pub const ILPR: u64 = 0x20;
+    /// Integer Baud Rate (R/W)
+    pub const IBRD: u64 = 0x24;
+    /// Fractional Baud Rate (R/W)
+    pub const FBRD: u64 = 0x28;
+    /// Line Control Register (R/W)
+    pub const LCR_H: u64 = 0x2C;
+    /// Control Register (R/W)
+    pub const CR: u64 = 0x30;
+    /// Interrupt FIFO Level Select (R/W)
+    pub const IFLS: u64 = 0x34;
+    /// Interrupt Mask Set/Clear (R/W)
+    pub const IMSC: u64 = 0x38;
+    /// Raw Interrupt Status (RO)
+    pub const RIS: u64 = 0x3C;
+    /// Masked Interrupt Status (RO)
+    pub const MIS: u64 = 0x40;
+    /// Interrupt Clear Register (WO)
+    pub const ICR: u64 = 0x44;
+    /// DMA Control Register (R/W)
+    pub const DMACR: u64 = 0x48;
 
-/// PL011 UART Flag Register bits
-const UART_FR_TXFE: u64 = 1 << 7; // Transmit FIFO Empty
+    /// Peripheral ID registers (RO)
+    pub const PERIPHID0: u64 = 0xFE0;
+    pub const PERIPHID1: u64 = 0xFE4;
+    pub const PERIPHID2: u64 = 0xFE8;
+    pub const PERIPHID3: u64 = 0xFEC;
+
+    /// Cell ID registers (RO)
+    pub const CELLID0: u64 = 0xFF0;
+    pub const CELLID1: u64 = 0xFF4;
+    pub const CELLID2: u64 = 0xFF8;
+    pub const CELLID3: u64 = 0xFFC;
+}
+
+/// Flag Register bits
+#[allow(dead_code)]
+mod fr_bits {
+    /// Clear To Send
+    pub const CTS: u64 = 1 << 0;
+    /// Data Set Ready
+    pub const DSR: u64 = 1 << 1;
+    /// Data Carrier Detect
+    pub const DCD: u64 = 1 << 2;
+    /// UART Busy
+    pub const BUSY: u64 = 1 << 3;
+    /// Receive FIFO Empty
+    pub const RXFE: u64 = 1 << 4;
+    /// Transmit FIFO Full
+    pub const TXFF: u64 = 1 << 5;
+    /// Receive FIFO Full
+    pub const RXFF: u64 = 1 << 6;
+    /// Transmit FIFO Empty
+    pub const TXFE: u64 = 1 << 7;
+    /// Ring Indicator
+    pub const RI: u64 = 1 << 8;
+}
+
+/// Control Register bits
+#[allow(dead_code)]
+mod cr_bits {
+    /// UART Enable
+    pub const UARTEN: u64 = 1 << 0;
+    /// SIR Enable (IrDA)
+    pub const SIREN: u64 = 1 << 1;
+    /// SIR Low-Power
+    pub const SIRLP: u64 = 1 << 2;
+    /// Loopback Enable
+    pub const LBE: u64 = 1 << 7;
+    /// Transmit Enable
+    pub const TXE: u64 = 1 << 8;
+    /// Receive Enable
+    pub const RXE: u64 = 1 << 9;
+    /// Data Transmit Ready
+    pub const DTR: u64 = 1 << 10;
+    /// Request To Send
+    pub const RTS: u64 = 1 << 11;
+    /// CTS Hardware Flow Control
+    pub const CTSEN: u64 = 1 << 14;
+    /// RTS Hardware Flow Control
+    pub const RTSEN: u64 = 1 << 15;
+}
+
+/// Line Control Register bits
+#[allow(dead_code)]
+mod lcr_h_bits {
+    /// Send Break
+    pub const BRK: u64 = 1 << 0;
+    /// Parity Enable
+    pub const PEN: u64 = 1 << 1;
+    /// Even Parity Select
+    pub const EPS: u64 = 1 << 2;
+    /// Two Stop Bits Select
+    pub const STP2: u64 = 1 << 3;
+    /// Enable FIFOs
+    pub const FEN: u64 = 1 << 4;
+    /// Word Length (bits 5-6)
+    pub const WLEN_MASK: u64 = 0x3 << 5;
+    /// Stick Parity Select
+    pub const SPS: u64 = 1 << 7;
+}
+
+/// Interrupt bits (for IMSC, RIS, MIS, ICR)
+#[allow(dead_code)]
+mod int_bits {
+    /// Ring Indicator Modem
+    pub const RIMIM: u64 = 1 << 0;
+    /// Clear To Send Modem
+    pub const CTSMIM: u64 = 1 << 1;
+    /// Data Carrier Detect Modem
+    pub const DCDMIM: u64 = 1 << 2;
+    /// Data Set Ready Modem
+    pub const DSRMIM: u64 = 1 << 3;
+    /// Receive
+    pub const RXIM: u64 = 1 << 4;
+    /// Transmit
+    pub const TXIM: u64 = 1 << 5;
+    /// Receive Timeout
+    pub const RTIM: u64 = 1 << 6;
+    /// Framing Error
+    pub const FEIM: u64 = 1 << 7;
+    /// Parity Error
+    pub const PEIM: u64 = 1 << 8;
+    /// Break Error
+    pub const BEIM: u64 = 1 << 9;
+    /// Overrun Error
+    pub const OEIM: u64 = 1 << 10;
+}
 
 /// PL011 UART device emulator
 ///
-/// This emulates the ARM PL011 UART controller.
-/// - Writes to UART_DR (0x00) output characters to stdout
-/// - Reads from UART_FR (0x18) return TXFE (TX FIFO empty)
+/// ARM PL011 UART コントローラーをエミュレート。
+/// - UART_DR (0x00) への書き込みは stdout に出力
+/// - UART_FR (0x18) の読み取りは TXFE (TX FIFO empty) を返す
+/// - 各種制御レジスタをサポート
 pub struct Pl011Uart {
     base_addr: u64,
+    /// Integer Baud Rate Divisor
+    ibrd: u64,
+    /// Fractional Baud Rate Divisor
+    fbrd: u64,
+    /// Line Control Register
+    lcr_h: u64,
+    /// Control Register
+    cr: u64,
+    /// Interrupt FIFO Level Select
+    ifls: u64,
+    /// Interrupt Mask Set/Clear
+    imsc: u64,
+    /// Raw Interrupt Status
+    ris: u64,
+    /// DMA Control Register
+    dmacr: u64,
+    /// Receive Status / Error Clear
+    rsr: u64,
 }
 
 impl Pl011Uart {
@@ -26,7 +179,59 @@ impl Pl011Uart {
     /// # Arguments
     /// * `base_addr` - Base address of the UART device (typically 0x09000000)
     pub fn new(base_addr: u64) -> Self {
-        Self { base_addr }
+        Self {
+            base_addr,
+            ibrd: 0,
+            fbrd: 0,
+            lcr_h: 0,
+            // Default: UART disabled, TX/RX enabled
+            cr: cr_bits::TXE | cr_bits::RXE,
+            // Default FIFO levels: 1/2 full
+            ifls: 0b010_010,
+            imsc: 0,
+            ris: int_bits::TXIM, // TX interrupt always asserted (FIFO empty)
+            dmacr: 0,
+            rsr: 0,
+        }
+    }
+
+    /// Check if UART is enabled
+    #[allow(dead_code)]
+    fn is_enabled(&self) -> bool {
+        (self.cr & cr_bits::UARTEN) != 0
+    }
+
+    /// Check if transmit is enabled
+    #[allow(dead_code)]
+    fn is_tx_enabled(&self) -> bool {
+        (self.cr & cr_bits::TXE) != 0
+    }
+
+    /// Get Flag Register value
+    fn get_flags(&self) -> u64 {
+        let mut flags = 0u64;
+
+        // TX FIFO is always empty (we flush immediately)
+        flags |= fr_bits::TXFE;
+
+        // RX FIFO is always empty (no input support yet)
+        flags |= fr_bits::RXFE;
+
+        // CTS is always asserted (ready to send)
+        flags |= fr_bits::CTS;
+
+        // DSR is always asserted
+        flags |= fr_bits::DSR;
+
+        // DCD is always asserted
+        flags |= fr_bits::DCD;
+
+        flags
+    }
+
+    /// Get Masked Interrupt Status
+    fn get_mis(&self) -> u64 {
+        self.ris & self.imsc
     }
 }
 
@@ -40,33 +245,101 @@ impl MmioHandler for Pl011Uart {
     }
 
     fn read(&mut self, offset: u64, _size: usize) -> Result<u64, Box<dyn Error>> {
-        match offset {
-            UART_FR => {
-                // Always report TX FIFO as empty (ready to transmit)
-                Ok(UART_FR_TXFE)
+        let value = match offset {
+            regs::DR => {
+                // No receive data available, return 0
+                0
             }
-            _ => {
-                // Other registers return 0
-                Ok(0)
-            }
-        }
+            regs::RSR_ECR => self.rsr,
+            regs::FR => self.get_flags(),
+            regs::ILPR => 0, // Not implemented
+            regs::IBRD => self.ibrd,
+            regs::FBRD => self.fbrd,
+            regs::LCR_H => self.lcr_h,
+            regs::CR => self.cr,
+            regs::IFLS => self.ifls,
+            regs::IMSC => self.imsc,
+            regs::RIS => self.ris,
+            regs::MIS => self.get_mis(),
+            regs::ICR => 0, // Write-only register
+            regs::DMACR => self.dmacr,
+
+            // Peripheral ID (PL011 identification)
+            regs::PERIPHID0 => 0x11, // Part number [7:0]
+            regs::PERIPHID1 => 0x10, // Part number [11:8], Designer [3:0]
+            regs::PERIPHID2 => 0x14, // Revision, Designer [7:4]
+            regs::PERIPHID3 => 0x00, // Configuration
+
+            // Cell ID (PrimeCell identification)
+            regs::CELLID0 => 0x0D,
+            regs::CELLID1 => 0xF0,
+            regs::CELLID2 => 0x05,
+            regs::CELLID3 => 0xB1,
+
+            _ => 0,
+        };
+
+        Ok(value)
     }
 
     fn write(&mut self, offset: u64, value: u64, _size: usize) -> Result<(), Box<dyn Error>> {
         match offset {
-            UART_DR => {
-                // Extract the character (lower 8 bits)
+            regs::DR => {
+                // Only output if UART and TX are enabled
+                // (但し earlycon 対応のため、無効でも出力する)
                 let ch = (value & 0xFF) as u8;
-                // Output to stdout
                 print!("{}", ch as char);
                 io::stdout().flush()?;
-                Ok(())
+            }
+            regs::RSR_ECR => {
+                // Writing any value clears the error flags
+                self.rsr = 0;
+            }
+            regs::FR => {
+                // Flag register is read-only, ignore
+            }
+            regs::ILPR => {
+                // IrDA not implemented, ignore
+            }
+            regs::IBRD => {
+                self.ibrd = value & 0xFFFF;
+            }
+            regs::FBRD => {
+                self.fbrd = value & 0x3F;
+            }
+            regs::LCR_H => {
+                self.lcr_h = value & 0xFF;
+            }
+            regs::CR => {
+                self.cr = value & 0xFFFF;
+            }
+            regs::IFLS => {
+                self.ifls = value & 0x3F;
+            }
+            regs::IMSC => {
+                self.imsc = value & 0x7FF;
+            }
+            regs::RIS => {
+                // Read-only, ignore
+            }
+            regs::MIS => {
+                // Read-only, ignore
+            }
+            regs::ICR => {
+                // Clear the specified interrupt bits
+                self.ris &= !value;
+                // TX interrupt is always re-asserted (FIFO always empty)
+                self.ris |= int_bits::TXIM;
+            }
+            regs::DMACR => {
+                self.dmacr = value & 0x7;
             }
             _ => {
-                // Ignore writes to other registers
-                Ok(())
+                // Ignore writes to unknown registers
             }
         }
+
+        Ok(())
     }
 }
 
@@ -84,14 +357,16 @@ mod tests {
     #[test]
     fn test_uart_fr_read() {
         let mut uart = Pl011Uart::new(0x09000000);
-        let value = uart.read(UART_FR, 4).unwrap();
-        assert_eq!(value, UART_FR_TXFE);
+        let value = uart.read(regs::FR, 4).unwrap();
+        // TX FIFO empty, RX FIFO empty, CTS/DSR/DCD asserted
+        assert_ne!(value & fr_bits::TXFE, 0);
+        assert_ne!(value & fr_bits::RXFE, 0);
     }
 
     #[test]
     fn test_uart_unknown_register_read() {
         let mut uart = Pl011Uart::new(0x09000000);
-        let value = uart.read(0xFF, 4).unwrap();
+        let value = uart.read(0x100, 4).unwrap();
         assert_eq!(value, 0);
     }
 
@@ -99,13 +374,119 @@ mod tests {
     fn test_uart_dr_write() {
         let mut uart = Pl011Uart::new(0x09000000);
         // Writing 'A' (0x41) should succeed
-        uart.write(UART_DR, 0x41, 4).unwrap();
+        uart.write(regs::DR, 0x41, 4).unwrap();
     }
 
     #[test]
     fn test_uart_unknown_register_write() {
         let mut uart = Pl011Uart::new(0x09000000);
         // Writes to unknown registers should be ignored (no error)
-        uart.write(0xFF, 0x42, 4).unwrap();
+        uart.write(0x100, 0x42, 4).unwrap();
+    }
+
+    #[test]
+    fn test_uart_cr_read_write() {
+        let mut uart = Pl011Uart::new(0x09000000);
+
+        // Default: TX and RX enabled
+        let cr = uart.read(regs::CR, 4).unwrap();
+        assert_ne!(cr & cr_bits::TXE, 0);
+        assert_ne!(cr & cr_bits::RXE, 0);
+
+        // Enable UART
+        uart.write(regs::CR, cr_bits::UARTEN | cr_bits::TXE | cr_bits::RXE, 4)
+            .unwrap();
+        let cr = uart.read(regs::CR, 4).unwrap();
+        assert_ne!(cr & cr_bits::UARTEN, 0);
+    }
+
+    #[test]
+    fn test_uart_lcr_h_read_write() {
+        let mut uart = Pl011Uart::new(0x09000000);
+
+        // Write 8-bit, no parity, 1 stop bit, FIFO enabled
+        let lcr = lcr_h_bits::FEN | (0b11 << 5); // 8-bit word length
+        uart.write(regs::LCR_H, lcr, 4).unwrap();
+
+        let value = uart.read(regs::LCR_H, 4).unwrap();
+        assert_eq!(value, lcr);
+    }
+
+    #[test]
+    fn test_uart_baud_rate_registers() {
+        let mut uart = Pl011Uart::new(0x09000000);
+
+        // Set baud rate divisors
+        uart.write(regs::IBRD, 0x0027, 4).unwrap(); // Integer part
+        uart.write(regs::FBRD, 0x04, 4).unwrap(); // Fractional part
+
+        assert_eq!(uart.read(regs::IBRD, 4).unwrap(), 0x0027);
+        assert_eq!(uart.read(regs::FBRD, 4).unwrap(), 0x04);
+    }
+
+    #[test]
+    fn test_uart_interrupt_registers() {
+        let mut uart = Pl011Uart::new(0x09000000);
+
+        // Set interrupt mask
+        uart.write(regs::IMSC, int_bits::TXIM | int_bits::RXIM, 4)
+            .unwrap();
+        assert_eq!(
+            uart.read(regs::IMSC, 4).unwrap(),
+            int_bits::TXIM | int_bits::RXIM
+        );
+
+        // RIS should have TXIM set (TX FIFO empty)
+        let ris = uart.read(regs::RIS, 4).unwrap();
+        assert_ne!(ris & int_bits::TXIM, 0);
+
+        // MIS should reflect masked interrupts
+        let mis = uart.read(regs::MIS, 4).unwrap();
+        assert_ne!(mis & int_bits::TXIM, 0);
+    }
+
+    #[test]
+    fn test_uart_icr_clears_interrupts() {
+        let mut uart = Pl011Uart::new(0x09000000);
+
+        // Clear TX interrupt
+        uart.write(regs::ICR, int_bits::TXIM, 4).unwrap();
+
+        // But TXIM should be re-asserted (FIFO always empty)
+        let ris = uart.read(regs::RIS, 4).unwrap();
+        assert_ne!(ris & int_bits::TXIM, 0);
+    }
+
+    #[test]
+    fn test_uart_peripheral_id() {
+        let mut uart = Pl011Uart::new(0x09000000);
+
+        // Check PL011 identification
+        assert_eq!(uart.read(regs::PERIPHID0, 4).unwrap(), 0x11);
+        assert_eq!(uart.read(regs::PERIPHID1, 4).unwrap(), 0x10);
+        assert_eq!(uart.read(regs::PERIPHID2, 4).unwrap(), 0x14);
+    }
+
+    #[test]
+    fn test_uart_cell_id() {
+        let mut uart = Pl011Uart::new(0x09000000);
+
+        // Check PrimeCell identification
+        assert_eq!(uart.read(regs::CELLID0, 4).unwrap(), 0x0D);
+        assert_eq!(uart.read(regs::CELLID1, 4).unwrap(), 0xF0);
+        assert_eq!(uart.read(regs::CELLID2, 4).unwrap(), 0x05);
+        assert_eq!(uart.read(regs::CELLID3, 4).unwrap(), 0xB1);
+    }
+
+    #[test]
+    fn test_uart_rsr_ecr() {
+        let mut uart = Pl011Uart::new(0x09000000);
+
+        // RSR should be 0 initially
+        assert_eq!(uart.read(regs::RSR_ECR, 4).unwrap(), 0);
+
+        // Writing clears error flags (no-op since RSR is 0)
+        uart.write(regs::RSR_ECR, 0xFF, 4).unwrap();
+        assert_eq!(uart.read(regs::RSR_ECR, 4).unwrap(), 0);
     }
 }

--- a/tests/earlycon_test.rs
+++ b/tests/earlycon_test.rs
@@ -1,0 +1,271 @@
+//! Earlycon (UART 出力) テスト
+//!
+//! UART PL011 への出力が正しく動作することを確認するテスト。
+//! 実際の Linux カーネルの earlycon ドライバと同様の動作をテストする。
+
+use hypervisor::devices::uart::Pl011Uart;
+use hypervisor::mmio::MmioHandler;
+use hypervisor::Hypervisor;
+
+/// UART のベースアドレス
+const UART_BASE: u64 = 0x0900_0000;
+
+/// UART レジスタオフセット
+const UART_DR: u64 = 0x00;
+const UART_FR: u64 = 0x18;
+const UART_CR: u64 = 0x30;
+
+/// Flag Register bits
+const FR_TXFE: u64 = 1 << 7; // TX FIFO Empty
+
+/// Control Register bits
+const CR_UARTEN: u64 = 1 << 0;
+const CR_TXE: u64 = 1 << 8;
+
+/// UART に 1 文字出力する ARM64 命令列を生成
+///
+/// 入力: X0 = 出力する文字
+/// 処理: UART_FR を読んで TXFE を確認し、UART_DR に書き込む
+fn generate_uart_putchar_instructions(uart_base: u64) -> Vec<u32> {
+    // UART ベースアドレスを X1 に設定
+    let base_lo = (uart_base & 0xFFFF) as u32;
+    let base_hi = ((uart_base >> 16) & 0xFFFF) as u32;
+
+    vec![
+        // X1 = UART_BASE
+        0xD280_0001 | (base_lo << 5), // MOV X1, #base_lo
+        0xF2A0_0001 | (base_hi << 5), // MOVK X1, #base_hi, LSL #16
+        // X2 = UART_FR offset
+        0xD280_0302, // MOV X2, #0x18
+        // X3 = UART_DR offset
+        0xD280_0003, // MOV X3, #0x0
+        // UART_DR に書き込み (str w0, [x1, x3])
+        0xB823_0020, // str w0, [x1, x3]
+        // BRK で停止
+        0xD420_0000, // BRK #0
+    ]
+}
+
+/// UART に文字列を出力する ARM64 命令列を生成
+///
+/// 文字列データは命令列の後に配置され、相対アドレスで参照される。
+fn generate_uart_puts_instructions(uart_base: u64, message: &str) -> Vec<u32> {
+    let base_lo = (uart_base & 0xFFFF) as u32;
+    let base_hi = ((uart_base >> 16) & 0xFFFF) as u32;
+
+    let mut instructions = vec![
+        // X1 = UART_BASE
+        0xD280_0001 | (base_lo << 5), // MOV X1, #base_lo
+        0xF2A0_0001 | (base_hi << 5), // MOVK X1, #base_hi, LSL #16
+        // X2 = 文字列へのオフセット (命令数 * 4 + PC)
+        // ADR X2, string_data (PC 相対)
+        // 命令数: 7 (このブロック) + 文字列データの開始位置
+    ];
+
+    // 文字列の長さ
+    let msg_len = message.len();
+
+    // ループ: 各文字を UART に出力
+    // X3 = カウンタ (0 から開始)
+    // X4 = 文字列長
+    instructions.extend([
+        0xD280_0003,                            // MOV X3, #0 (カウンタ)
+        0xD280_0004 | ((msg_len as u32) << 5),  // MOV X4, #msg_len
+        // loop:
+        0xEB04_007F, // CMP X3, X4
+        0x5400_00A0, // B.EQ end (offset = 5 instructions = 20 bytes)
+        // ADR X5, string_data
+        0x1000_0085, // ADR X5, .+16 (4 instructions ahead)
+        // X0 = string[X3]
+        0x3863_6CA0, // LDRB W0, [X5, X3]
+        // str w0, [x1] - UART_DR に書き込み
+        0xB900_0020, // STR W0, [X1]
+        // X3++
+        0x9100_0463, // ADD X3, X3, #1
+        // B loop
+        0x17FF_FFFA, // B loop (offset = -6 instructions = -24 bytes)
+        // end:
+        0xD420_0000, // BRK #0
+    ]);
+
+    // 文字列データを命令として追加 (4 バイト境界)
+    let msg_bytes = message.as_bytes();
+    for chunk in msg_bytes.chunks(4) {
+        let mut word = 0u32;
+        for (i, &byte) in chunk.iter().enumerate() {
+            word |= (byte as u32) << (i * 8);
+        }
+        instructions.push(word);
+    }
+
+    instructions
+}
+
+/// 簡単な UART 出力テスト（単一文字）
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements (run locally with --ignored)"]
+fn uart_に1文字出力できる() {
+    let guest_addr = 0x4000_0000u64;
+    let mut hv = Hypervisor::new(guest_addr, 0x1000_0000).expect("Failed to create hypervisor");
+
+    // UART デバイスを登録
+    let uart = Pl011Uart::new(UART_BASE);
+    hv.register_mmio_handler(Box::new(uart));
+
+    // 'A' を UART に出力する命令
+    // MOVZ encoding: sf=1, opc=10, 100101, hw, imm16, Rd
+    // MOVZ X0, #0x41 = 0xD280_0820
+    // MOVZ X1, #0x0900, LSL #16 = 0xD2A1_2001
+    let instructions: [u32; 5] = [
+        0xD280_0820, // MOVZ X0, #0x41 ('A')
+        0xD2A1_2001, // MOVZ X1, #0x0900, LSL #16 (UART_BASE = 0x0900_0000)
+        0xB900_0020, // STR W0, [X1]
+        0xD420_0000, // BRK #0
+        0x0000_0000, // padding
+    ];
+
+    hv.write_instructions(&instructions)
+        .expect("Failed to write instructions");
+
+    let result = hv.run(None, None, None).expect("Failed to run");
+
+    // BRK で停止したことを確認
+    let ec = result
+        .exception_syndrome
+        .map(|s| (s >> 26) & 0x3f)
+        .unwrap_or(0);
+    assert_eq!(ec, 0x3c, "Expected BRK exception");
+}
+
+/// UART の Flag Register を読めることを確認
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements (run locally with --ignored)"]
+fn uart_flag_registerを読める() {
+    let guest_addr = 0x4000_0000u64;
+    let mut hv = Hypervisor::new(guest_addr, 0x1000_0000).expect("Failed to create hypervisor");
+
+    // UART デバイスを登録
+    let uart = Pl011Uart::new(UART_BASE);
+    hv.register_mmio_handler(Box::new(uart));
+
+    // UART_FR を読み取る命令
+    // MOVZ X1, #0x0900, LSL #16 = 0xD2A1_2001
+    // ADD X1, X1, #0x18 (FR offset)
+    // LDR W0, [X1]
+    let instructions: [u32; 5] = [
+        0xD2A1_2001, // MOVZ X1, #0x0900, LSL #16 (UART_BASE)
+        0x9100_6021, // ADD X1, X1, #0x18 (FR offset)
+        0xB940_0020, // LDR W0, [X1]
+        0xD420_0000, // BRK #0
+        0x0000_0000, // padding
+    ];
+
+    hv.write_instructions(&instructions)
+        .expect("Failed to write instructions");
+
+    let result = hv.run(None, None, None).expect("Failed to run");
+
+    // BRK で停止したことを確認
+    let ec = result
+        .exception_syndrome
+        .map(|s| (s >> 26) & 0x3f)
+        .unwrap_or(0);
+    assert_eq!(ec, 0x3c, "Expected BRK exception");
+
+    // X0 に TXFE フラグが含まれていることを確認
+    assert_ne!(
+        result.registers[0] & FR_TXFE,
+        0,
+        "Expected TXFE flag to be set"
+    );
+}
+
+/// UART の Control Register を読み書きできることを確認
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements (run locally with --ignored)"]
+fn uart_control_registerを読み書きできる() {
+    let guest_addr = 0x4000_0000u64;
+    let mut hv = Hypervisor::new(guest_addr, 0x1000_0000).expect("Failed to create hypervisor");
+
+    // UART デバイスを登録
+    let uart = Pl011Uart::new(UART_BASE);
+    hv.register_mmio_handler(Box::new(uart));
+
+    // UART_CR に書き込み、読み取りする命令
+    // X0 = CR_UARTEN | CR_TXE | CR_RXE = 0x301
+    // X1 = UART_BASE + 0x30
+    // str w0, [x1]; ldr w2, [x1]
+    let cr_value = CR_UARTEN | CR_TXE | (1 << 9); // UARTEN | TXE | RXE = 0x301
+    let instructions: [u32; 7] = [
+        0xD280_0000 | ((cr_value as u32 & 0xFFFF) << 5), // MOVZ X0, #cr_value
+        0xD2A1_2001,                                     // MOVZ X1, #0x0900, LSL #16 (UART_BASE)
+        0x9100_C021,                                     // ADD X1, X1, #0x30 (CR offset)
+        0xB900_0020,                                     // STR W0, [X1]
+        0xB940_0022,                                     // LDR W2, [X1]
+        0xD420_0000,                                     // BRK #0
+        0x0000_0000,                                     // padding
+    ];
+
+    hv.write_instructions(&instructions)
+        .expect("Failed to write instructions");
+
+    let result = hv.run(None, None, None).expect("Failed to run");
+
+    // BRK で停止したことを確認
+    let ec = result
+        .exception_syndrome
+        .map(|s| (s >> 26) & 0x3f)
+        .unwrap_or(0);
+    assert_eq!(ec, 0x3c, "Expected BRK exception");
+
+    // X2 に書き込んだ値が読み取れることを確認
+    assert_eq!(
+        result.registers[2] & 0xFFFF,
+        cr_value,
+        "Expected CR value to match"
+    );
+}
+
+/// Unit test: Pl011Uart の直接テスト
+#[test]
+fn uart_earlycon_シーケンスが動作する() {
+    let mut uart = Pl011Uart::new(UART_BASE);
+
+    // 1. Flag Register を読んで TXFE を確認
+    let fr = uart.read(UART_FR, 4).unwrap();
+    assert_ne!(fr & FR_TXFE, 0, "TX FIFO should be empty");
+
+    // 2. Control Register を設定 (UART enable, TX enable)
+    uart.write(UART_CR, CR_UARTEN | CR_TXE, 4).unwrap();
+
+    // 3. 文字列 "Hello" を出力
+    for ch in b"Hello" {
+        // TXFE を確認 (常に empty なので省略可能)
+        let fr = uart.read(UART_FR, 4).unwrap();
+        assert_ne!(fr & FR_TXFE, 0);
+
+        // 文字を出力
+        uart.write(UART_DR, *ch as u64, 4).unwrap();
+    }
+}
+
+/// Unit test: 連続した UART 出力
+#[test]
+fn uart_連続出力が動作する() {
+    let mut uart = Pl011Uart::new(UART_BASE);
+
+    // Linux earlycon と同様のシーケンス
+    let message = "Booting Linux...\n";
+
+    for ch in message.bytes() {
+        // TX FIFO が空になるまで待つ (エミュレーションでは常に空)
+        loop {
+            let fr = uart.read(UART_FR, 4).unwrap();
+            if (fr & FR_TXFE) != 0 {
+                break;
+            }
+        }
+        // 文字を出力
+        uart.write(UART_DR, ch as u64, 4).unwrap();
+    }
+}

--- a/tests/mini_kernel_test.rs
+++ b/tests/mini_kernel_test.rs
@@ -1,0 +1,155 @@
+//! ミニカーネル起動テスト
+//!
+//! UART に "Hello from mini kernel!" と出力する簡単なカーネルを実行し、
+//! ハイパーバイザーの Linux 起動機能をテストする。
+
+use hypervisor::boot::device_tree::{generate_device_tree, DeviceTreeConfig};
+use hypervisor::boot::kernel::KernelImage;
+use hypervisor::devices::uart::Pl011Uart;
+use hypervisor::mmio::MmioHandler;
+use hypervisor::Hypervisor;
+
+/// メモリベースアドレス
+const RAM_BASE: u64 = 0x4000_0000;
+/// カーネルエントリーポイント
+const KERNEL_ENTRY: u64 = 0x4008_0000;
+/// UART ベースアドレス
+const UART_BASE: u64 = 0x0900_0000;
+/// DTB アドレス
+const DTB_ADDR: u64 = 0x4400_0000;
+
+/// ミニカーネルのバイナリを生成
+///
+/// このカーネルは:
+/// 1. UART に "Hello" と出力
+/// 2. WFI で待機
+/// 3. HVC で PSCI_SYSTEM_OFF を呼び出して終了
+fn create_mini_kernel() -> Vec<u8> {
+    // ARM64 機械語命令
+    // MOVZ Xd, #imm16, LSL #(hw*16) encoding:
+    // sf=1, opc=10, 100101, hw, imm16, Rd
+    // MOVZ X1, #0x0900, LSL #16 = 0xD2A1_2001
+    let instructions: Vec<u32> = vec![
+        // === 初期化 ===
+        // X1 = UART_BASE (0x0900_0000)
+        // MOVZ X1, #0x0900, LSL #16
+        0xD2A1_2001,
+        // === 'H' を出力 (0x48) ===
+        // MOVZ X0, #0x48
+        0xD280_0900,
+        // STR W0, [X1]
+        0xB900_0020,
+        // === 'e' を出力 (0x65) ===
+        0xD280_0CA0, // MOVZ X0, #0x65
+        0xB900_0020, // STR W0, [X1]
+        // === 'l' を出力 (0x6C) ===
+        0xD280_0D80, // MOVZ X0, #0x6C
+        0xB900_0020, // STR W0, [X1]
+        // === 'l' を出力 (0x6C) ===
+        0xD280_0D80, // MOVZ X0, #0x6C
+        0xB900_0020, // STR W0, [X1]
+        // === 'o' を出力 (0x6F) ===
+        0xD280_0DE0, // MOVZ X0, #0x6F
+        0xB900_0020, // STR W0, [X1]
+        // === '\n' を出力 (0x0A) ===
+        0xD280_0140, // MOVZ X0, #0x0A
+        0xB900_0020, // STR W0, [X1]
+        // === PSCI_SYSTEM_OFF (HVC) ===
+        // X0 = PSCI_SYSTEM_OFF (0x84000008)
+        // MOVZ X0, #0x8
+        0xD280_0100,
+        // MOVK X0, #0x8400, LSL #16 (correct encoding: F2B0_8000)
+        0xF2B0_8000,
+        // HVC #0
+        0xD400_0002,
+        // === 無限ループ (到達しないはず) ===
+        0xD503_201F, // WFI
+        0x17FF_FFFF, // B -4 (WFI に戻る)
+    ];
+
+    // 命令をバイト列に変換
+    let mut bytes = Vec::new();
+    for instr in instructions {
+        bytes.extend_from_slice(&instr.to_le_bytes());
+    }
+    bytes
+}
+
+/// ミニカーネルが UART に出力して PSCI_SYSTEM_OFF で終了することを確認
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements (run locally with --ignored)"]
+fn mini_kernel_がuartに出力して終了する() {
+    // 128MB RAM
+    let mem_size = 128 * 1024 * 1024;
+    let mut hv = Hypervisor::new(RAM_BASE, mem_size).expect("Failed to create hypervisor");
+
+    // UART デバイスを登録
+    let uart = Pl011Uart::new(UART_BASE);
+    hv.register_mmio_handler(Box::new(uart));
+
+    // ミニカーネルを作成
+    let kernel_data = create_mini_kernel();
+    let kernel = KernelImage::from_bytes(kernel_data, Some(KERNEL_ENTRY));
+
+    // カーネルをブート
+    let result = hv
+        .boot_linux(&kernel, "console=ttyAMA0 earlycon", Some(DTB_ADDR))
+        .expect("Failed to boot");
+
+    // HVC (PSCI_SYSTEM_OFF) で VM Exit したことを確認
+    // EC = 0x16 (HVC) で終了するはず
+    let ec = result
+        .exception_syndrome
+        .map(|s| (s >> 26) & 0x3f)
+        .unwrap_or(0);
+
+    // PSCI_SYSTEM_OFF は VM Exit を返すので、正常終了
+    println!("Mini kernel exited with EC=0x{:x}", ec);
+}
+
+/// Device Tree が正しく生成されることを確認
+#[test]
+fn device_tree_が正しく生成される() {
+    let config = DeviceTreeConfig {
+        memory_base: RAM_BASE,
+        memory_size: 128 * 1024 * 1024,
+        uart_base: UART_BASE,
+        virtio_base: 0x0A00_0000,
+        gic_dist_base: 0x0800_0000,
+        gic_cpu_base: 0x0801_0000,
+        cmdline: "console=ttyAMA0 earlycon".to_string(),
+    };
+
+    let dtb = generate_device_tree(&config).expect("Failed to generate DTB");
+
+    // DTB が生成されたことを確認
+    assert!(!dtb.is_empty());
+
+    // DTB マジックナンバー (0xD00DFEED, big-endian)
+    assert_eq!(dtb[0], 0xD0);
+    assert_eq!(dtb[1], 0x0D);
+    assert_eq!(dtb[2], 0xFE);
+    assert_eq!(dtb[3], 0xED);
+}
+
+/// KernelImage が正しく作成されることを確認
+#[test]
+fn kernel_image_が正しく作成される() {
+    let kernel_data = create_mini_kernel();
+    let kernel = KernelImage::from_bytes(kernel_data.clone(), Some(KERNEL_ENTRY));
+
+    assert_eq!(kernel.entry_point(), KERNEL_ENTRY);
+    assert_eq!(kernel.data().len(), kernel_data.len());
+}
+
+/// UART への直接書き込みテスト
+#[test]
+fn uart_に直接書き込める() {
+    let mut uart = Pl011Uart::new(UART_BASE);
+
+    // "Hello\n" を出力
+    for ch in b"Hello\n" {
+        uart.write(0x00, *ch as u64, 4)
+            .expect("Failed to write to UART");
+    }
+}

--- a/tests/wfi_psci_test.rs
+++ b/tests/wfi_psci_test.rs
@@ -1,0 +1,218 @@
+//! WFI/WFE と PSCI ハンドリングのテスト
+//!
+//! これらのテストは Hypervisor.framework の entitlements が必要です。
+//! ローカルで実行する場合は `cargo test --ignored` を使用してください。
+
+use hypervisor::Hypervisor;
+
+/// WFI 命令が正しくハンドリングされ、PC が進むことを確認
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements (run locally with --ignored)"]
+fn wfi_命令が正しくハンドリングされる() {
+    let mut hv = Hypervisor::new(0x4000_0000, 0x100_0000).expect("Failed to create hypervisor");
+
+    // WFI 命令: D5 03 20 1F
+    // BRK #0: D4 20 00 00
+    let instructions: [u32; 2] = [
+        0xD503_201F, // WFI
+        0xD420_0000, // BRK #0
+    ];
+
+    hv.write_instructions(&instructions)
+        .expect("Failed to write instructions");
+
+    let result = hv.run(None, None, None).expect("Failed to run");
+
+    // BRK で停止するはず（WFI をスキップして）
+    let ec = result
+        .exception_syndrome
+        .map(|s| (s >> 26) & 0x3f)
+        .unwrap_or(0);
+    assert_eq!(ec, 0x3c, "Expected BRK exception (EC=0x3c)");
+
+    // PC は BRK 命令の位置（0x4000_0004）
+    assert_eq!(result.pc, 0x4000_0004);
+}
+
+/// WFE 命令が正しくハンドリングされ、PC が進むことを確認
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements (run locally with --ignored)"]
+fn wfe_命令が正しくハンドリングされる() {
+    let mut hv = Hypervisor::new(0x4000_0000, 0x100_0000).expect("Failed to create hypervisor");
+
+    // WFE 命令: D5 03 20 5F
+    // BRK #0: D4 20 00 00
+    let instructions: [u32; 2] = [
+        0xD503_205F, // WFE
+        0xD420_0000, // BRK #0
+    ];
+
+    hv.write_instructions(&instructions)
+        .expect("Failed to write instructions");
+
+    let result = hv.run(None, None, None).expect("Failed to run");
+
+    // BRK で停止するはず（WFE をスキップして）
+    let ec = result
+        .exception_syndrome
+        .map(|s| (s >> 26) & 0x3f)
+        .unwrap_or(0);
+    assert_eq!(ec, 0x3c, "Expected BRK exception (EC=0x3c)");
+
+    // PC は BRK 命令の位置（0x4000_0004）
+    assert_eq!(result.pc, 0x4000_0004);
+}
+
+/// HVC 命令で PSCI_VERSION を呼び出し、正しいバージョンを取得
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements (run locally with --ignored)"]
+fn hvc_psci_version_を呼び出せる() {
+    let mut hv = Hypervisor::new(0x4000_0000, 0x100_0000).expect("Failed to create hypervisor");
+
+    // MOV X0, #0x84000000 (PSCI_VERSION)
+    // HVC #0
+    // BRK #0
+    let instructions: [u32; 5] = [
+        0xD280_0000, // MOV X0, #0x0
+        0xF2B0_8000, // MOVK X0, #0x8400, LSL #16 (correct encoding)
+        0xD400_0002, // HVC #0
+        0xD420_0000, // BRK #0
+        0x0000_0000, // padding
+    ];
+
+    hv.write_instructions(&instructions)
+        .expect("Failed to write instructions");
+
+    // EL1h モード (0x3c5) で実行
+    let result = hv.run(Some(0x3c5), None, None).expect("Failed to run");
+
+    // BRK で停止
+    let ec = result
+        .exception_syndrome
+        .map(|s| (s >> 26) & 0x3f)
+        .unwrap_or(0);
+    assert_eq!(ec, 0x3c, "Expected BRK exception");
+
+    // X0 には PSCI 1.0 (0x0001_0000) が返されるはず
+    assert_eq!(
+        result.registers[0], 0x0001_0000,
+        "Expected PSCI version 1.0"
+    );
+}
+
+/// HVC で PSCI_FEATURES を呼び出し、VERSION がサポートされていることを確認
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements (run locally with --ignored)"]
+fn hvc_psci_features_でversionがサポートされている() {
+    let mut hv = Hypervisor::new(0x4000_0000, 0x100_0000).expect("Failed to create hypervisor");
+
+    // X0 = PSCI_FEATURES (0x8400000A)
+    // X1 = PSCI_VERSION (0x84000000)
+    // HVC #0
+    // BRK #0
+    let instructions: [u32; 7] = [
+        0xD280_0140, // MOV X0, #0xA
+        0xF2B0_8000, // MOVK X0, #0x8400, LSL #16 (correct encoding)
+        0xD280_0001, // MOV X1, #0x0
+        0xF2B0_8001, // MOVK X1, #0x8400, LSL #16 (correct encoding)
+        0xD400_0002, // HVC #0
+        0xD420_0000, // BRK #0
+        0x0000_0000, // padding
+    ];
+
+    hv.write_instructions(&instructions)
+        .expect("Failed to write instructions");
+
+    // EL1h モード (0x3c5) で実行
+    let result = hv.run(Some(0x3c5), None, None).expect("Failed to run");
+
+    // BRK で停止
+    let ec = result
+        .exception_syndrome
+        .map(|s| (s >> 26) & 0x3f)
+        .unwrap_or(0);
+    assert_eq!(ec, 0x3c, "Expected BRK exception");
+
+    // X0 = 0 (PSCI_SUCCESS = サポートされている)
+    assert_eq!(result.registers[0], 0, "Expected PSCI_SUCCESS (supported)");
+}
+
+/// HVC で PSCI_CPU_ON を呼び出し、ALREADY_ON を取得
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements (run locally with --ignored)"]
+fn hvc_psci_cpu_on_はalready_onを返す() {
+    let mut hv = Hypervisor::new(0x4000_0000, 0x100_0000).expect("Failed to create hypervisor");
+
+    // X0 = PSCI_CPU_ON (0xC4000003)
+    // X1 = target_cpu = 0
+    // X2 = entry_point = 0
+    // X3 = context_id = 0
+    // HVC #0
+    // BRK #0
+    let instructions: [u32; 8] = [
+        0xD280_0060, // MOV X0, #0x3
+        0xF2B8_8000, // MOVK X0, #0xC400, LSL #16
+        0xD280_0001, // MOV X1, #0
+        0xD280_0002, // MOV X2, #0
+        0xD280_0003, // MOV X3, #0
+        0xD400_0002, // HVC #0
+        0xD420_0000, // BRK #0
+        0x0000_0000, // padding
+    ];
+
+    hv.write_instructions(&instructions)
+        .expect("Failed to write instructions");
+
+    // EL1h モード (0x3c5) で実行
+    let result = hv.run(Some(0x3c5), None, None).expect("Failed to run");
+
+    // BRK で停止
+    let ec = result
+        .exception_syndrome
+        .map(|s| (s >> 26) & 0x3f)
+        .unwrap_or(0);
+    assert_eq!(ec, 0x3c, "Expected BRK exception");
+
+    // X0 = PSCI_E_ALREADY_ON (-4)
+    assert_eq!(
+        result.registers[0], 0xFFFF_FFFF_FFFF_FFFC,
+        "Expected PSCI_E_ALREADY_ON"
+    );
+}
+
+/// HVC で未知の PSCI 関数を呼び出し、NOT_SUPPORTED を取得
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements (run locally with --ignored)"]
+fn hvc_未知の関数はnot_supportedを返す() {
+    let mut hv = Hypervisor::new(0x4000_0000, 0x100_0000).expect("Failed to create hypervisor");
+
+    // X0 = 未知の関数 (0xFFFFFFFF)
+    // HVC #0
+    // BRK #0
+    let instructions: [u32; 5] = [
+        0x9280_0000, // MOV X0, #-1 (0xFFFFFFFF_FFFFFFFF)
+        0xD400_0002, // HVC #0
+        0xD420_0000, // BRK #0
+        0x0000_0000, // padding
+        0x0000_0000, // padding
+    ];
+
+    hv.write_instructions(&instructions)
+        .expect("Failed to write instructions");
+
+    // EL1h モード (0x3c5) で実行
+    let result = hv.run(Some(0x3c5), None, None).expect("Failed to run");
+
+    // BRK で停止
+    let ec = result
+        .exception_syndrome
+        .map(|s| (s >> 26) & 0x3f)
+        .unwrap_or(0);
+    assert_eq!(ec, 0x3c, "Expected BRK exception");
+
+    // X0 = PSCI_E_NOT_SUPPORTED (-1)
+    assert_eq!(
+        result.registers[0], 0xFFFF_FFFF_FFFF_FFFF,
+        "Expected PSCI_E_NOT_SUPPORTED"
+    );
+}


### PR DESCRIPTION
## Summary
- WFI/WFE ハンドリングと PSCI 1.0 実装
- UART PL011 全レジスタ実装
- Linux カーネルビルド手順ドキュメント追加
- ARM64 命令エンコーディングと HVC PC 進行バグ修正

## Changes

### Week 3: WFI/WFE と PSCI
- EC=0x01 (WFI/WFE) ハンドリング実装
- EC=0x16 (HVC) ハンドリングと PSCI 1.0 実装
  - PSCI_VERSION, CPU_SUSPEND, CPU_OFF, CPU_ON
  - AFFINITY_INFO, SYSTEM_OFF, SYSTEM_RESET, FEATURES

### Week 4: UART PL011 完全実装
- 全レジスタ実装 (DR, FR, CR, IBRD, FBRD, LCR_H, IMSC, etc.)
- Peripheral ID / Cell ID レジスタ
- Data Abort ISS デコード改善 (ISV, SRT, FnV)

### Week 5: カーネルビルドと Earlycon
- `tests/earlycon_test.rs`: UART 出力テスト
- `tests/mini_kernel_test.rs`: UART + PSCI_SYSTEM_OFF テスト
- `docs/linux-kernel-build.md`: クロスコンパイル手順

### Week 6: バグ修正
- ARM64 MOVK 命令エンコーディング修正
  - 正: `0xF2B0_8000` (MOVK X0, #0x8400, LSL #16)
- **HVC PC 進行バグ修正（重要）**
  - HVC は "preferred return" exception なので PC 進行不要
  - 発見: ELR_EL2 は HVC + 4 を指すため、手動で +4 すると BRK をスキップしていた

## Test plan
- [x] ユニットテスト: 97 件通過
- [x] Hypervisor.framework テスト: 24 件通過
  - earlycon: 3
  - interrupt_injection: 6
  - mini_kernel: 1 (UART 出力 "Hello" 成功)
  - sysreg: 7
  - wfi_psci: 6
- [x] `cargo test` 成功
- [x] `cargo test -- --ignored` 成功（ローカル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WFI/WFE instruction handling with timer polling support.
  * Implemented comprehensive PSCI functionality via HVC interface.
  * Expanded PL011 UART with complete register support and device state management.

* **Bug Fixes**
  * Fixed ARM64 MOVK instruction encoding and HW field shift handling.
  * Corrected HVC PC progression behavior.
  * Improved Data Abort ISS decoding for accurate fault address and register handling.

* **Documentation**
  * Added Linux kernel build guide for ARM64 cross-compilation on macOS.

* **Tests**
  * Added WFI/PSCI integration tests and UART early console tests.
  * Expanded test coverage to 105+ total tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->