### PR TITLE
feat: 🎉 Linux カーネル v6.6 起動成功 - Phase 4 Week 6 完了

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,8 @@ dist
 
 /target
 test_disk.img
+
+# Generated kernel images
+output/
+disk.img
+test_disk.img

--- a/Dockerfile.linux-build
+++ b/Dockerfile.linux-build
@@ -1,0 +1,18 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc-aarch64-linux-gnu \
+    binutils-aarch64-linux-gnu \
+    bison \
+    flex \
+    libncurses-dev \
+    libssl-dev \
+    libelf-dev \
+    bc \
+    git \
+    wget \
+    cpio \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build

--- a/scripts/build-linux-kernel.sh
+++ b/scripts/build-linux-kernel.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Linux カーネルビルドスクリプト
+# ハイパーバイザー用の最小構成 ARM64 カーネルをビルドする
+
+set -e
+
+KERNEL_VERSION="6.6"
+KERNEL_DIR="/build/linux-${KERNEL_VERSION}"
+
+echo "=== Linux kernel build for hypervisor ==="
+
+# カーネルソースがなければ取得
+if [ ! -d "$KERNEL_DIR" ]; then
+    echo "Downloading Linux kernel v${KERNEL_VERSION}..."
+    git clone --depth 1 --branch "v${KERNEL_VERSION}" \
+        https://github.com/torvalds/linux.git "$KERNEL_DIR"
+fi
+
+cd "$KERNEL_DIR"
+
+# defconfig をベースに最小構成を作成
+echo "Creating minimal config..."
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- defconfig
+
+# 追加設定を適用
+cat >> .config << 'EOF'
+# UART console
+CONFIG_SERIAL_AMBA_PL011=y
+CONFIG_SERIAL_AMBA_PL011_CONSOLE=y
+
+# Early printk
+CONFIG_EARLY_PRINTK=y
+CONFIG_EARLY_PRINTK_DIRECT=y
+
+# GIC
+CONFIG_ARM_GIC=y
+CONFIG_ARM_GIC_V3=y
+
+# Timer
+CONFIG_ARM_ARCH_TIMER=y
+
+# Disable unnecessary features for minimal boot
+CONFIG_MODULES=n
+CONFIG_NET=n
+CONFIG_WLAN=n
+CONFIG_WIRELESS=n
+CONFIG_BT=n
+CONFIG_SOUND=n
+CONFIG_USB=n
+CONFIG_INPUT=n
+CONFIG_HID=n
+CONFIG_DRM=n
+CONFIG_FB=n
+CONFIG_VGA_CONSOLE=n
+
+# Enable debug
+CONFIG_DEBUG_INFO=y
+CONFIG_PRINTK=y
+CONFIG_PRINTK_TIME=y
+
+# Command line
+CONFIG_CMDLINE="console=ttyAMA0 earlycon=pl011,0x09000000 loglevel=8"
+CONFIG_CMDLINE_FORCE=y
+EOF
+
+# 設定を更新
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- olddefconfig
+
+# ビルド
+echo "Building kernel..."
+make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- Image -j$(nproc)
+
+echo "=== Build complete ==="
+echo "Kernel image: ${KERNEL_DIR}/arch/arm64/boot/Image"
+ls -lh "${KERNEL_DIR}/arch/arm64/boot/Image"
+
+# 出力ディレクトリにコピー
+cp "${KERNEL_DIR}/arch/arm64/boot/Image" /output/Image
+echo "Copied to /output/Image"

--- a/tests/earlycon_test.rs
+++ b/tests/earlycon_test.rs
@@ -57,9 +57,9 @@ fn generate_uart_puts_instructions(uart_base: u64, message: &str) -> Vec<u32> {
         // X1 = UART_BASE
         0xD280_0001 | (base_lo << 5), // MOV X1, #base_lo
         0xF2A0_0001 | (base_hi << 5), // MOVK X1, #base_hi, LSL #16
-        // X2 = 文字列へのオフセット (命令数 * 4 + PC)
-        // ADR X2, string_data (PC 相対)
-        // 命令数: 7 (このブロック) + 文字列データの開始位置
+                                      // X2 = 文字列へのオフセット (命令数 * 4 + PC)
+                                      // ADR X2, string_data (PC 相対)
+                                      // 命令数: 7 (このブロック) + 文字列データの開始位置
     ];
 
     // 文字列の長さ
@@ -69,8 +69,8 @@ fn generate_uart_puts_instructions(uart_base: u64, message: &str) -> Vec<u32> {
     // X3 = カウンタ (0 から開始)
     // X4 = 文字列長
     instructions.extend([
-        0xD280_0003,                            // MOV X3, #0 (カウンタ)
-        0xD280_0004 | ((msg_len as u32) << 5),  // MOV X4, #msg_len
+        0xD280_0003,                           // MOV X3, #0 (カウンタ)
+        0xD280_0004 | ((msg_len as u32) << 5), // MOV X4, #msg_len
         // loop:
         0xEB04_007F, // CMP X3, X4
         0x5400_00A0, // B.EQ end (offset = 5 instructions = 20 bytes)

--- a/tests/linux_boot_test.rs
+++ b/tests/linux_boot_test.rs
@@ -1,0 +1,146 @@
+//! Linux カーネル起動テスト
+//!
+//! 実際の Linux カーネルをハイパーバイザーで起動し、
+//! earlycon 出力を確認する。
+
+use hypervisor::boot::kernel::KernelImage;
+use hypervisor::devices::uart::Pl011Uart;
+use hypervisor::mmio::MmioHandler;
+use hypervisor::Hypervisor;
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+/// UART 出力を収集する構造体
+struct UartCollector {
+    inner: Pl011Uart,
+    output: Arc<Mutex<Vec<u8>>>,
+}
+
+impl UartCollector {
+    fn new(base_addr: u64, output: Arc<Mutex<Vec<u8>>>) -> Self {
+        Self {
+            inner: Pl011Uart::new(base_addr),
+            output,
+        }
+    }
+}
+
+impl MmioHandler for UartCollector {
+    fn base(&self) -> u64 {
+        self.inner.base()
+    }
+
+    fn size(&self) -> u64 {
+        self.inner.size()
+    }
+
+    fn read(&mut self, offset: u64, size: usize) -> Result<u64, Box<dyn Error>> {
+        self.inner.read(offset, size)
+    }
+
+    fn write(&mut self, offset: u64, value: u64, size: usize) -> Result<(), Box<dyn Error>> {
+        // DR レジスタ (offset 0x00) への書き込みを収集
+        if offset == 0x00 && size >= 1 {
+            let byte = (value & 0xFF) as u8;
+            if let Ok(mut output) = self.output.lock() {
+                output.push(byte);
+            }
+            // 標準出力にも出力
+            print!("{}", byte as char);
+        }
+        self.inner.write(offset, value, size)
+    }
+}
+
+// Send + Sync は inner の Pl011Uart が既に実装済み
+unsafe impl Send for UartCollector {}
+unsafe impl Sync for UartCollector {}
+
+/// メモリ定数
+const RAM_BASE: u64 = 0x4000_0000;
+const RAM_SIZE: usize = 256 * 1024 * 1024; // 256MB
+const KERNEL_ENTRY: u64 = 0x4008_0000;
+const UART_BASE: u64 = 0x0900_0000;
+const DTB_ADDR: u64 = 0x4400_0000;
+
+/// カーネルイメージのパス
+const KERNEL_IMAGE_PATH: &str = "output/Image";
+
+/// Linux カーネルを起動して earlycon 出力を確認
+#[test]
+#[ignore = "requires Hypervisor.framework entitlements and kernel image (run locally with --ignored)"]
+fn linux_カーネルが起動してuart出力する() {
+    // カーネルイメージを読み込み
+    let kernel_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(KERNEL_IMAGE_PATH);
+    if !kernel_path.exists() {
+        eprintln!("Kernel image not found at {:?}", kernel_path);
+        eprintln!("Build it first with: docker run ... scripts/build-linux-kernel.sh");
+        return;
+    }
+
+    let kernel_data = fs::read(&kernel_path).expect("Failed to read kernel image");
+    println!("Loaded kernel image: {} bytes", kernel_data.len());
+
+    let kernel = KernelImage::from_bytes(kernel_data, Some(KERNEL_ENTRY));
+
+    // ハイパーバイザーを作成
+    let mut hv = Hypervisor::new(RAM_BASE, RAM_SIZE).expect("Failed to create hypervisor");
+
+    // UART 出力を収集
+    let uart_output = Arc::new(Mutex::new(Vec::new()));
+    let uart = UartCollector::new(UART_BASE, Arc::clone(&uart_output));
+    hv.register_mmio_handler(Box::new(uart));
+
+    // カーネルを起動
+    println!("\n=== Starting Linux kernel boot ===\n");
+
+    let result = hv
+        .boot_linux(
+            &kernel,
+            "console=ttyAMA0 earlycon=pl011,0x09000000 loglevel=8",
+            Some(DTB_ADDR),
+        )
+        .expect("Failed to boot kernel");
+
+    // 終了理由を表示
+    println!("\n\n=== Kernel execution ended ===");
+    println!("Exit reason: {:?}", result.exit_reason);
+    if let Some(esr) = result.exception_syndrome {
+        let ec = (esr >> 26) & 0x3f;
+        println!("Exception Class (EC): 0x{:x}", ec);
+    }
+    println!("PC at exit: 0x{:x}", result.pc);
+
+    // UART 出力を表示
+    let output = uart_output.lock().unwrap();
+    let output_str = String::from_utf8_lossy(&output);
+    println!("\n=== UART Output ({} bytes) ===", output.len());
+    println!("{}", output_str);
+
+    // 出力があることを確認
+    assert!(
+        !output.is_empty(),
+        "Expected some UART output from the kernel"
+    );
+}
+
+/// カーネルイメージが存在するかチェック
+#[test]
+fn カーネルイメージが存在する() {
+    let kernel_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(KERNEL_IMAGE_PATH);
+    if kernel_path.exists() {
+        let metadata = fs::metadata(&kernel_path).expect("Failed to get metadata");
+        println!(
+            "Kernel image found: {:?} ({} MB)",
+            kernel_path,
+            metadata.len() / 1024 / 1024
+        );
+        assert!(metadata.len() > 1024 * 1024, "Kernel image seems too small");
+    } else {
+        println!("Kernel image not found at {:?}", kernel_path);
+        println!("This is expected if you haven't built the kernel yet.");
+        println!("Build it with: docker run ... scripts/build-linux-kernel.sh");
+    }
+}


### PR DESCRIPTION
## Summary

🎉 **Linux 6.6.0 カーネルが自作ハイパーバイザー上で起動しました！**

自作ハイパーバイザーで実際の Linux カーネルを起動し、UART から起動ログを出力することを確認しました。

## 主な変更

### Data Abort ハンドラーの IPA 取得バグ修正
- Stage 2 フォールトでは FAR_EL1 ではなく `exit_info.exception.physical_address` (IPA) を使用
- `handle_data_abort()` に `fault_ipa` 引数を追加

### 未知のシステムレジスタアクセスのエミュレート
- 読み取り時は 0 を返し、書き込み時は無視して続行
- これにより Linux カーネルがより先に進めるようになった

### Docker でのカーネルビルド環境
- `Dockerfile.linux-build`: Ubuntu 22.04 ベースのビルド環境
- `scripts/build-linux-kernel.sh`: カーネルビルドスクリプト
- 最小構成の defconfig で 42MB の Image を生成

### テスト
- `tests/linux_boot_test.rs`: 実 Linux カーネル起動テスト
- `UartCollector` で UART 出力をキャプチャ
- 3904 バイトの正常な起動ログを確認

## 確認できた起動ログ

```
Booting Linux on physical CPU 0x0000000000 [0x610f0000]
Linux version 6.6.0 ...
Machine model: hypervisor-virt
earlycon: pl11 at MMIO 0x0000000009000000
printk: bootconsole [pl11] enabled
arch_timer: cp15 timer(s) running at 24.00MHz (virt)
Calibrating delay loop ... 48.00 BogoMIPS
LSM: initializing lsm=capability,integrity
Mount-cache hash table entries: 512
```

## Test plan
- [x] `cargo test` - ユニットテスト通過
- [x] `cargo test -- --ignored` - Hypervisor.framework テスト通過
- [x] `linux_boot_test.rs` - Linux カーネル起動テスト通過

## 残課題
- GIC レジスタへの MMIO アクセス (0x8000xxx) が未処理

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Linux v6.6 kernel boot support with automated ARM64 cross-compilation environment via Docker.
  * Added kernel boot verification with UART output capture for console logging.

* **Bug Fixes**
  * Fixed Data Abort fault address handling to use provided physical addresses correctly.
  * Added system register access emulation to support kernel initialization.

* **Chores**
  * Updated .gitignore for generated kernel images and build artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->