### PR TITLE
feat: 共有 GIC アーキテクチャでタイマー割り込み配信を修正

### DIFF
--- a/src/devices/gic.rs
+++ b/src/devices/gic.rs
@@ -496,9 +496,7 @@ impl MmioHandler for SharedGicWrapper {
 
 /// 共有 GIC を作成するヘルパー関数
 pub fn create_shared_gic(base_addr: u64) -> SharedGic {
-    let mut gic = Gic::new();
-    gic.base_addr = base_addr;
-    Arc::new(Mutex::new(gic))
+    Arc::new(Mutex::new(Gic::with_base(base_addr)))
 }
 
 #[cfg(test)]

--- a/src/devices/gic.rs
+++ b/src/devices/gic.rs
@@ -6,6 +6,10 @@
 
 use crate::mmio::MmioHandler;
 use std::error::Error;
+use std::sync::{Arc, Mutex};
+
+/// 共有 GIC タイプ
+pub type SharedGic = Arc<Mutex<Gic>>;
 
 /// GICv2 のデフォルトベースアドレス
 pub const GIC_DIST_BASE: u64 = 0x0800_0000;
@@ -441,6 +445,54 @@ impl MmioHandler for Gic {
         }
         Ok(())
     }
+}
+
+/// 共有 GIC を MMIO ハンドラとして使うためのラッパー
+///
+/// `Arc<Mutex<Gic>>` を使って GIC を共有しながら、MMIO ハンドラとして登録できます。
+#[derive(Debug)]
+pub struct SharedGicWrapper {
+    gic: SharedGic,
+    base_addr: u64,
+}
+
+impl SharedGicWrapper {
+    /// 新しい共有 GIC ラッパーを作成
+    pub fn new(gic: SharedGic, base_addr: u64) -> Self {
+        Self { gic, base_addr }
+    }
+
+    /// 共有 GIC への参照を取得
+    pub fn gic(&self) -> &SharedGic {
+        &self.gic
+    }
+}
+
+impl MmioHandler for SharedGicWrapper {
+    fn base(&self) -> u64 {
+        self.base_addr
+    }
+
+    fn size(&self) -> u64 {
+        GIC_DIST_SIZE + GIC_CPU_SIZE
+    }
+
+    fn read(&mut self, offset: u64, size: usize) -> Result<u64, Box<dyn Error>> {
+        let mut gic = self.gic.lock().map_err(|e| format!("GIC lock error: {}", e))?;
+        gic.read(offset, size)
+    }
+
+    fn write(&mut self, offset: u64, value: u64, size: usize) -> Result<(), Box<dyn Error>> {
+        let mut gic = self.gic.lock().map_err(|e| format!("GIC lock error: {}", e))?;
+        gic.write(offset, value, size)
+    }
+}
+
+/// 共有 GIC を作成するヘルパー関数
+pub fn create_shared_gic(base_addr: u64) -> SharedGic {
+    let mut gic = Gic::new();
+    gic.base_addr = base_addr;
+    Arc::new(Mutex::new(gic))
 }
 
 #[cfg(test)]

--- a/src/devices/gic.rs
+++ b/src/devices/gic.rs
@@ -478,12 +478,18 @@ impl MmioHandler for SharedGicWrapper {
     }
 
     fn read(&mut self, offset: u64, size: usize) -> Result<u64, Box<dyn Error>> {
-        let mut gic = self.gic.lock().map_err(|e| format!("GIC lock error: {}", e))?;
+        let mut gic = self
+            .gic
+            .lock()
+            .map_err(|e| format!("GIC lock error: {}", e))?;
         gic.read(offset, size)
     }
 
     fn write(&mut self, offset: u64, value: u64, size: usize) -> Result<(), Box<dyn Error>> {
-        let mut gic = self.gic.lock().map_err(|e| format!("GIC lock error: {}", e))?;
+        let mut gic = self
+            .gic
+            .lock()
+            .map_err(|e| format!("GIC lock error: {}", e))?;
         gic.write(offset, value, size)
     }
 }

--- a/src/devices/interrupt.rs
+++ b/src/devices/interrupt.rs
@@ -2,7 +2,7 @@
 //!
 //! GIC と Timer を統合して、タイマー割り込みを自動的に GIC に配信します。
 
-use super::gic::{Gic, GIC_DIST_SIZE};
+use super::gic::{SharedGic, GIC_DIST_SIZE};
 use super::timer::{Timer, PHYS_TIMER_IRQ, VIRT_TIMER_IRQ};
 use crate::mmio::MmioHandler;
 
@@ -19,8 +19,8 @@ const GICC_CTLR: u64 = 0x000;
 /// GIC と Timer を統合管理し、タイマー割り込みを自動的に GIC にルーティングします。
 #[derive(Debug)]
 pub struct InterruptController {
-    /// GIC (Generic Interrupt Controller)
-    pub gic: Gic,
+    /// 共有 GIC (Generic Interrupt Controller)
+    pub gic: SharedGic,
     /// ARM Generic Timer
     pub timer: Timer,
 }
@@ -32,10 +32,15 @@ impl Default for InterruptController {
 }
 
 impl InterruptController {
-    /// 新しい割り込みコントローラーを作成
+    /// 新しい割り込みコントローラーを作成（内部 GIC を使用）
     pub fn new() -> Self {
+        Self::with_gic(super::gic::create_shared_gic(super::gic::GIC_DIST_BASE))
+    }
+
+    /// 既存の共有 GIC を使って割り込みコントローラーを作成
+    pub fn with_gic(gic: SharedGic) -> Self {
         Self {
-            gic: Gic::new(),
+            gic,
             timer: Timer::new(),
         }
     }
@@ -45,52 +50,56 @@ impl InterruptController {
     /// タイマーがペンディング状態の場合、対応する IRQ を GIC にセットします。
     /// VM のメインループで定期的に呼び出す必要があります。
     pub fn poll_timer_irqs(&mut self) {
+        let mut gic = self.gic.lock().unwrap();
+
         // 物理タイマー
         if self.timer.phys_timer_pending() {
-            self.gic.set_irq_pending(PHYS_TIMER_IRQ);
+            gic.set_irq_pending(PHYS_TIMER_IRQ);
         }
 
         // 仮想タイマー
         if self.timer.virt_timer_pending() {
-            self.gic.set_irq_pending(VIRT_TIMER_IRQ);
+            gic.set_irq_pending(VIRT_TIMER_IRQ);
         }
     }
 
     /// ペンディング中の IRQ があるかチェック
     pub fn has_pending_irq(&self) -> bool {
-        self.gic.get_highest_pending_irq().is_some()
+        let gic = self.gic.lock().unwrap();
+        gic.get_highest_pending_irq().is_some()
     }
 
     /// 最高優先度のペンディング IRQ を取得
     pub fn get_pending_irq(&self) -> Option<u32> {
-        self.gic.get_highest_pending_irq()
+        let gic = self.gic.lock().unwrap();
+        gic.get_highest_pending_irq()
     }
 
     /// GIC を有効化
     pub fn enable(&mut self) {
+        let mut gic = self.gic.lock().unwrap();
         // GICD_CTLR = 1
-        self.gic.write(GICD_CTLR, 1, 4).unwrap();
+        gic.write(GICD_CTLR, 1, 4).unwrap();
         // GICC_CTLR = 1
-        self.gic.write(GIC_DIST_SIZE + GICC_CTLR, 1, 4).unwrap();
+        gic.write(GIC_DIST_SIZE + GICC_CTLR, 1, 4).unwrap();
     }
 
     /// タイマー IRQ を有効化
     pub fn enable_timer_irqs(&mut self) {
+        let mut gic = self.gic.lock().unwrap();
         // PPI は IRQ 16-31 で、ISENABLER[0] のビット 16-31 に対応
         // 物理タイマー IRQ 30 を有効化
         // 仮想タイマー IRQ 27 を有効化
         let mask = (1u32 << PHYS_TIMER_IRQ) | (1u32 << VIRT_TIMER_IRQ);
-        self.gic.write(GICD_ISENABLER, mask as u64, 4).unwrap();
+        gic.write(GICD_ISENABLER, mask as u64, 4).unwrap();
 
         // 優先度を設定 (中程度: 0x80)
         // IPRIORITYR はバイト単位でアクセス
         // IRQ 27 の優先度
-        self.gic
-            .write(GICD_IPRIORITYR + VIRT_TIMER_IRQ as u64, 0x80, 4)
+        gic.write(GICD_IPRIORITYR + VIRT_TIMER_IRQ as u64, 0x80, 4)
             .unwrap();
         // IRQ 30 の優先度
-        self.gic
-            .write(GICD_IPRIORITYR + PHYS_TIMER_IRQ as u64, 0x80, 4)
+        gic.write(GICD_IPRIORITYR + PHYS_TIMER_IRQ as u64, 0x80, 4)
             .unwrap();
     }
 
@@ -101,18 +110,21 @@ impl InterruptController {
 
     /// 割り込みを acknowledge して IRQ 番号を返す
     pub fn acknowledge(&mut self) -> u32 {
-        self.gic.acknowledge_irq()
+        let mut gic = self.gic.lock().unwrap();
+        gic.acknowledge_irq()
     }
 
     /// 割り込み処理完了を通知
     pub fn end_of_interrupt(&mut self, irq: u32) {
-        self.gic.end_of_interrupt(irq);
+        let mut gic = self.gic.lock().unwrap();
+        gic.end_of_interrupt(irq);
     }
 
     /// GIC が有効かどうか
     pub fn is_enabled(&mut self) -> bool {
-        let gicd = self.gic.read(GICD_CTLR, 4).unwrap();
-        let gicc = self.gic.read(GIC_DIST_SIZE + GICC_CTLR, 4).unwrap();
+        let mut gic = self.gic.lock().unwrap();
+        let gicd = gic.read(GICD_CTLR, 4).unwrap();
+        let gicc = gic.read(GIC_DIST_SIZE + GICC_CTLR, 4).unwrap();
         gicd != 0 && gicc != 0
     }
 }
@@ -140,8 +152,9 @@ mod tests {
         let mut ic = InterruptController::new();
         ic.enable_timer_irqs();
 
-        // ISENABLER[0] を読み取って確認
-        let enabled = ic.gic.read(GICD_ISENABLER, 4).unwrap() as u32;
+        // ISENABLER[0] を読み取って確認（MMIO インターフェース経由）
+        let mut gic = ic.gic.lock().unwrap();
+        let enabled = gic.read(GICD_ISENABLER, 4).unwrap() as u32;
         // 物理タイマー IRQ 30 が有効
         assert_ne!(enabled & (1 << 30), 0);
         // 仮想タイマー IRQ 27 が有効

--- a/src/devices/interrupt.rs
+++ b/src/devices/interrupt.rs
@@ -2,7 +2,7 @@
 //!
 //! GIC と Timer を統合して、タイマー割り込みを自動的に GIC に配信します。
 
-use super::gic::{SharedGic, GIC_DIST_SIZE};
+use super::gic::{create_shared_gic, SharedGic, GIC_DIST_BASE, GIC_DIST_SIZE};
 use super::timer::{Timer, PHYS_TIMER_IRQ, VIRT_TIMER_IRQ};
 use crate::mmio::MmioHandler;
 
@@ -34,7 +34,7 @@ impl Default for InterruptController {
 impl InterruptController {
     /// 新しい割り込みコントローラーを作成（内部 GIC を使用）
     pub fn new() -> Self {
-        Self::with_gic(super::gic::create_shared_gic(super::gic::GIC_DIST_BASE))
+        Self::with_gic(create_shared_gic(GIC_DIST_BASE))
     }
 
     /// 既存の共有 GIC を使って割り込みコントローラーを作成

--- a/tests/linux_boot_test.rs
+++ b/tests/linux_boot_test.rs
@@ -6,7 +6,6 @@
 use applevisor::Reg;
 use hypervisor::boot::device_tree::{generate_device_tree, DeviceTreeConfig};
 use hypervisor::boot::kernel::KernelImage;
-use hypervisor::devices::gic::Gic;
 use hypervisor::devices::uart::Pl011Uart;
 use hypervisor::mmio::MmioHandler;
 use hypervisor::Hypervisor;
@@ -99,9 +98,7 @@ fn linux_カーネルが起動してuart出力する() {
     let uart = UartCollector::new(UART_BASE, Arc::clone(&uart_output));
     hv.register_mmio_handler(Box::new(uart));
 
-    // GIC を登録
-    let gic = Gic::with_base(GIC_BASE);
-    hv.register_mmio_handler(Box::new(gic));
+    // GIC は Hypervisor が自動的に登録する
 
     // カーネルを起動
     println!("\n=== Starting Linux kernel boot ===\n");
@@ -172,9 +169,7 @@ fn linux_カーネルがinitramfsでシェルを起動する() {
     let uart = UartCollector::new(UART_BASE, Arc::clone(&uart_output));
     hv.register_mmio_handler(Box::new(uart));
 
-    // GIC を登録
-    let gic = Gic::with_base(GIC_BASE);
-    hv.register_mmio_handler(Box::new(gic));
+    // GIC は Hypervisor が自動的に登録する
 
     // initramfs をメモリに配置
     let initramfs_end = INITRAMFS_ADDR + initramfs_data.len() as u64;


### PR DESCRIPTION
## Summary
- Hypervisor が自動的に共有 GIC を作成・登録するアーキテクチャを導入
- InterruptController と MMIO ハンドラが同じ GIC インスタンスを共有
- Linux カーネルが MMIO 経由で GIC を有効化すると、タイマー割り込みが正しく配信される

## 問題
以前の実装では、`InterruptController` 内の GIC と MMIO ハンドラとして登録される GIC が別々のインスタンスでした。そのため、Linux カーネルが MMIO 経由で GIC を有効化しても、`InterruptController` からは無効のままでした。これにより `has_pending_irq()` が常に `false` を返し、タイマー割り込みがゲストに配信されませんでした。

## 解決策
- `Arc<Mutex<Gic>>` (`SharedGic`) を導入し、GIC を共有可能に
- `SharedGicWrapper` を作成して `MmioHandler` を実装
- `Hypervisor::new()` で共有 GIC を自動作成・登録
- `InterruptController` は同じ `SharedGic` を使用

## 新規 API
- `SharedGic`: `Arc<Mutex<Gic>>` 型エイリアス
- `SharedGicWrapper`: `SharedGic` を MMIO ハンドラとして使うラッパー
- `create_shared_gic()`: 共有 GIC を作成するヘルパー関数
- `InterruptController::with_gic()`: 既存の `SharedGic` を使う新コンストラクタ

## テスト結果
- Linux カーネルが HugeTLB 初期化まで進行
- GIC が正常に認識 ("Root IRQ handler: gic_handle_irq")
- タイマーが正常に動作 ("arch_timer: cp15 timer(s) running at 24.00MHz")
- 全 98 ユニットテストがパス

## Test plan
- [x] `cargo test` - 全ユニットテストがパス
- [x] `cargo test linux_カーネルが起動してuart出力する -- --ignored` - カーネルが HugeTLB まで進行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Interrupt controller (GIC) is now automatically registered during system initialization.

* **Refactor**
  * Interrupt subsystem rewritten to use a shared, concurrency-safe GIC instance and unified MMIO registration.

* **Tests**
  * Boot tests updated to remove manual GIC setup and rely on automatic registration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->