### PR TITLE
feat: FIQ カーネルパニックを修正 - ソフトウェアタイマーエミュレーション

### DIFF
--- a/src/devices/timer.rs
+++ b/src/devices/timer.rs
@@ -252,23 +252,7 @@ impl Timer {
     pub fn write_sysreg(&mut self, reg: TimerReg, value: u64) -> Result<(), Box<dyn Error>> {
         let phys_counter = self.get_phys_counter();
         let virt_counter = self.get_virt_counter();
-
-        // デバッグ: 仮想タイマーへの書き込みをログ
-        static mut VIRT_TIMER_WRITE_COUNT: u64 = 0;
-        match reg {
-            TimerReg::CNTV_CTL_EL0 | TimerReg::CNTV_CVAL_EL0 | TimerReg::CNTV_TVAL_EL0 => {
-                unsafe {
-                    VIRT_TIMER_WRITE_COUNT += 1;
-                    if VIRT_TIMER_WRITE_COUNT <= 10 {
-                        eprintln!(
-                            "[VTIMER WRITE #{}] {:?} = 0x{:x}, counter = 0x{:x}",
-                            VIRT_TIMER_WRITE_COUNT, reg, value, virt_counter
-                        );
-                    }
-                }
-            }
-            _ => {}
-        }
+        let _ = virt_counter; // 将来のデバッグ用に保持
 
         match reg {
             TimerReg::CNTFRQ_EL0 => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,43 @@ impl Hypervisor {
         let _vm = ManuallyDrop::new(VirtualMachine::new()?);
         let vcpu = ManuallyDrop::new(Vcpu::new()?);
 
+        // 仮想タイマー割り込みをマスクして FIQ 配信を抑制
+        // これにより VTIMER_ACTIVATED イベントで GIC 経由の IRQ として配信できる
+        vcpu.set_vtimer_mask(true)?;
+
+        // vtimer_mask が正しく設定されたか確認
+        let vtimer_masked = vcpu.get_vtimer_mask()?;
+        eprintln!("[DEBUG] vtimer_mask set: {}", vtimer_masked);
+
+        // vtimer_offset を現在のハードウェアカウンタに設定
+        // これにより、ゲストの CNTVCT_EL0 は 0 から始まる
+        // FIQ 問題の根本原因: vtimer_offset=0 だと、ゲストは生のハードウェアカウンタ
+        // (~40兆 ticks、システム起動から19日) を見てしまう
+        // Linux がタイマーを設定すると、カウンタ >> CVAL となり即座に FIQ が発生
+        let hw_counter: u64;
+        unsafe {
+            std::arch::asm!("mrs {}, cntvct_el0", out(reg) hw_counter);
+        }
+        vcpu.set_vtimer_offset(hw_counter)?;
+        eprintln!(
+            "[DEBUG] vtimer_offset set to hw_counter: 0x{:x} (guest counter starts from 0)",
+            hw_counter
+        );
+
+        // 仮想タイマーを初期化
+        // CVAL=i64::MAX (符号付きで最大の正の値), CTL=0x2 (無効+マスク) を設定
+        // u64::MAX は符号付きで -1 となり即座に発火するため避ける
+        // i64::MAX は符号付きでも符号なしでも大きな正の値
+        // IMASK=1 を設定して FIQ を防止
+        vcpu.set_sys_reg(applevisor::SysReg::CNTV_CVAL_EL0, i64::MAX as u64)?;
+        vcpu.set_sys_reg(applevisor::SysReg::CNTV_CTL_EL0, 0x2)?; // ENABLE=0, IMASK=1
+        eprintln!("[DEBUG] vtimer initialized: CVAL=i64::MAX (0x{:x}), CTL=0x2 (IMASK=1)", i64::MAX as u64);
+
+
+        // vtimer_offset を確認
+        let verified_offset = vcpu.get_vtimer_offset().unwrap_or(0);
+        eprintln!("[DEBUG] vtimer_offset verified: 0x{:x}", verified_offset);
+
         let mut mem = Mapping::new(mem_size)?;
         mem.map(guest_addr, MemPerms::RWX)?;
 
@@ -204,10 +241,29 @@ impl Hypervisor {
             self.vcpu.set_trap_debug_exceptions(true)?;
         }
 
+        // デバッグ用カウンタ
+        static mut TIMER_PENDING_COUNT: u64 = 0;
+
         // ゲストプログラムを実行
         loop {
-            // タイマー IRQ をポーリングして GIC に反映
+            // ソフトウェアタイマー: poll_timer_irqs() がソフトウェアタイマーの状態をチェックし
+            // タイマーが発火していれば GIC に IRQ をセットする
+            let had_pending_before = self.interrupt_controller.has_pending_irq();
             self.interrupt_controller.poll_timer_irqs();
+            let has_pending_after = self.interrupt_controller.has_pending_irq();
+
+            // タイマー IRQ がペンディングになったかデバッグ
+            if !had_pending_before && has_pending_after {
+                unsafe {
+                    TIMER_PENDING_COUNT += 1;
+                    if TIMER_PENDING_COUNT <= 10 {
+                        eprintln!("[TIMER] IRQ pending #{}", TIMER_PENDING_COUNT);
+                    }
+                }
+            }
+
+            // FIQ をクリア（ハードウェアタイマーからの FIQ を抑制）
+            self.vcpu.set_pending_interrupt(InterruptType::FIQ, false)?;
 
             // ペンディング IRQ があれば vCPU にインジェクト
             if self.interrupt_controller.has_pending_irq() {
@@ -216,8 +272,162 @@ impl Hypervisor {
                 self.vcpu.set_pending_interrupt(InterruptType::IRQ, false)?;
             }
 
+            // ============================================================
+            // ハードウェア vtimer を完全に無効化して FIQ を防止
+            // ============================================================
+            // 戦略:
+            // 1. vcpu.run() 前にゲストが設定した CTL/CVAL を読み取り
+            // 2. その値をソフトウェアタイマーにコピー
+            // 3. ハードウェア vtimer を無効化 (ENABLE=0, IMASK=1, CVAL=i64::MAX)
+            // 4. vcpu.run()
+            // 5. ソフトウェアで発火を検出し GIC 経由で IRQ を注入
+            //
+            // 注: ゲストからの MSR 命令はトラップされないため、ゲストは
+            //     ハードウェアレジスタに直接書き込む。次の vcpu.run() 前に
+            //     その値を読み取ってソフトウェアタイマーに反映する。
+
+            // 前回の vcpu.run() でゲストが設定した CTL/CVAL を読み取り
+            // (リセット前に読み取ることで、ゲストの設定を正しく取得)
+            let guest_ctl = self
+                .vcpu
+                .get_sys_reg(applevisor::SysReg::CNTV_CTL_EL0)
+                .unwrap_or(0);
+            let guest_cval = self
+                .vcpu
+                .get_sys_reg(applevisor::SysReg::CNTV_CVAL_EL0)
+                .unwrap_or(i64::MAX as u64);
+
+            // ゲストが設定した値をソフトウェアタイマーにコピー
+            // これにより poll_timer_irqs() がソフトウェアで発火を検出できる
+            {
+                let virt_counter = self.interrupt_controller.timer.get_virt_counter();
+                self.interrupt_controller.timer.virt_timer.write_ctl(guest_ctl);
+                self.interrupt_controller.timer.virt_timer.write_cval(guest_cval);
+
+                // デバッグ: ゲストのタイマー設定をログ
+                static mut GUEST_TIMER_SYNC_COUNT: u64 = 0;
+                unsafe {
+                    GUEST_TIMER_SYNC_COUNT += 1;
+                    if GUEST_TIMER_SYNC_COUNT <= 20 || GUEST_TIMER_SYNC_COUNT % 5000 == 0 {
+                        let enabled = (guest_ctl & 0x1) != 0;
+                        let imask = (guest_ctl & 0x2) != 0;
+                        eprintln!(
+                            "[TIMER_SYNC #{}] guest_ctl=0x{:x} (enabled={}, imask={}), guest_cval=0x{:x}, sw_counter=0x{:x}",
+                            GUEST_TIMER_SYNC_COUNT, guest_ctl, enabled, imask, guest_cval, virt_counter
+                        );
+                    }
+                }
+            }
+
+            // FIQ 防止: ハードウェアタイマーを完全に無効化
+            // ゲストが vcpu.run() 中にタイマーを有効化しても、FIQ が発生しないようにする
+            // CVAL を遠い未来 (i64::MAX) に設定し、ENABLE=0, IMASK=1 を強制
+            // タイマー発火検出はハードウェアカウンタとゲストの CVAL を比較して行う
+            self.vcpu
+                .set_sys_reg(applevisor::SysReg::CNTV_CTL_EL0, 0x2)?; // ENABLE=0, IMASK=1
+            self.vcpu
+                .set_sys_reg(applevisor::SysReg::CNTV_CVAL_EL0, i64::MAX as u64)?;
+
+            // FIQ をクリア（万が一ペンディングしていても解除）
+            self.vcpu.set_pending_interrupt(InterruptType::FIQ, false)?;
+
             self.vcpu.run()?;
+
+            // vcpu.run() 後、ゲストが設定した値を再読み取り
+            let post_run_ctl = self
+                .vcpu
+                .get_sys_reg(applevisor::SysReg::CNTV_CTL_EL0)
+                .unwrap_or(0);
+            let post_run_cval = self
+                .vcpu
+                .get_sys_reg(applevisor::SysReg::CNTV_CVAL_EL0)
+                .unwrap_or(i64::MAX as u64);
+
+            // ゲストが vcpu.run() 中に設定した新しい値を使用
+            let timer_enabled = (post_run_ctl & 0x1) != 0;
+            let timer_imask = (post_run_ctl & 0x2) != 0;
+
+            // ハードウェアカウンタを読み取り、タイマー発火条件をチェック
+            // ゲストはこのカウンタを見ているので、これで比較する必要がある
+            let hw_counter: u64;
+            unsafe {
+                std::arch::asm!("mrs {}, cntvct_el0", out(reg) hw_counter);
+            }
+
+            // タイマー発火条件: ENABLE=1, カウンタ >= CVAL, IMASK=0
+            // 注: IRQ 注入のために IMASK=0 も要件に含める
+            //     IMASK=1 の場合、ゲストは割り込みを受け取りたくない
+            let timer_should_fire = timer_enabled && !timer_imask && hw_counter >= post_run_cval;
+
+            if timer_should_fire {
+                static mut SW_TIMER_FIRE_COUNT: u64 = 0;
+                unsafe {
+                    SW_TIMER_FIRE_COUNT += 1;
+                    if SW_TIMER_FIRE_COUNT <= 20 || SW_TIMER_FIRE_COUNT % 1000 == 0 {
+                        eprintln!(
+                            "[SW_TIMER_FIRE #{}] counter=0x{:x} >= cval=0x{:x} -> injecting IRQ via GIC",
+                            SW_TIMER_FIRE_COUNT, hw_counter, post_run_cval
+                        );
+                    }
+                }
+
+                // GIC 経由で IRQ を注入
+                let mut gic = self.interrupt_controller.gic.lock().unwrap();
+                gic.set_irq_pending(devices::timer::VIRT_TIMER_IRQ);
+            }
+
             let exit_info = self.vcpu.get_exit_info();
+
+            // GIC にペンディング IRQ があれば vCPU に IRQ を注入
+            if self.interrupt_controller.has_pending_irq() {
+                self.vcpu.set_pending_interrupt(InterruptType::IRQ, true)?;
+            }
+
+            // デバッグ: exit reason を定期的にログ
+            static mut EXIT_COUNT: u64 = 0;
+            static mut WFI_COUNT: u64 = 0;
+            static mut MMIO_COUNT: u64 = 0;
+            static mut VTIMER_COUNT: u64 = 0;
+            static mut OTHER_EXCEPTION_COUNT: u64 = 0;
+            unsafe {
+                EXIT_COUNT += 1;
+                match exit_info.reason {
+                    applevisor::ExitReason::EXCEPTION => {
+                        let ec = (exit_info.exception.syndrome >> 26) & 0x3f;
+                        if ec == 0x01 {
+                            // WFI/WFE
+                            WFI_COUNT += 1;
+                            if WFI_COUNT <= 5 || WFI_COUNT % 10000 == 0 {
+                                eprintln!("[WFI #{}] at exit #{}", WFI_COUNT, EXIT_COUNT);
+                            }
+                        } else if ec == 0x24 {
+                            // Data abort (MMIO)
+                            MMIO_COUNT += 1;
+                        } else {
+                            OTHER_EXCEPTION_COUNT += 1;
+                        }
+                    }
+                    applevisor::ExitReason::VTIMER_ACTIVATED => {
+                        VTIMER_COUNT += 1;
+                        eprintln!("[EXIT #{}] VTIMER_ACTIVATED!", EXIT_COUNT);
+                    }
+                    _ => {}
+                }
+                // 5000 回ごとにサマリーとタイマー状態を出力
+                if EXIT_COUNT % 5000 == 0 {
+                    // ゲストのタイマー状態を表示
+                    let istatus = timer_enabled && hw_counter >= post_run_cval;
+                    eprintln!(
+                        "[TIMER STATE @{}] CTL=0x{:x} (enable={}, imask={}, istatus={}), CVAL=0x{:x}, counter=0x{:x}",
+                        EXIT_COUNT, post_run_ctl, timer_enabled, timer_imask, istatus, post_run_cval, hw_counter
+                    );
+                    let gic_pending = self.interrupt_controller.has_pending_irq();
+                    eprintln!(
+                        "[STATS @{}] WFI={}, MMIO={}, VTIMER_ACTIVATED={}, OTHER_EXC={}, GIC_pending={}",
+                        EXIT_COUNT, WFI_COUNT, MMIO_COUNT, VTIMER_COUNT, OTHER_EXCEPTION_COUNT, gic_pending
+                    );
+                }
+            }
 
             // 汎用レジスタを取得
             let registers = [
@@ -334,11 +544,35 @@ impl Hypervisor {
                 }
             } else if let applevisor::ExitReason::VTIMER_ACTIVATED = exit_info.reason {
                 // 仮想タイマーがアクティブになった
+                // vtimer_mask が true なので、FIQ は直接配信されず、ここでハンドリングする
+
+                // デバッグログ
+                static mut VTIMER_ACTIVATED_COUNT: u64 = 0;
+                unsafe {
+                    VTIMER_ACTIVATED_COUNT += 1;
+                    if VTIMER_ACTIVATED_COUNT <= 10 {
+                        eprintln!("[VTIMER_ACTIVATED #{}] Timer fired!", VTIMER_ACTIVATED_COUNT);
+                    }
+                }
+
                 // タイマー IRQ をポーリングして GIC に反映
                 self.interrupt_controller.poll_timer_irqs();
 
-                // 続行（タイマー割り込みは GIC 経由で配信される）
-                // ゲストが GIC IAR を読むとき、acknowledge() が呼ばれる
+                // 仮想タイマー IRQ を GIC にセット (IRQ 27 = Virtual Timer)
+                {
+                    let mut gic = self.interrupt_controller.gic.lock().unwrap();
+                    gic.set_irq_pending(devices::timer::VIRT_TIMER_IRQ);
+                }
+
+                // GIC が有効で割り込みがペンディングしていれば vCPU に IRQ を注入
+                {
+                    let gic = self.interrupt_controller.gic.lock().unwrap();
+                    if gic.has_pending_interrupt() {
+                        self.vcpu.set_pending_interrupt(InterruptType::IRQ, true)?;
+                    }
+                }
+
+                // 続行（タイマー割り込みは GIC 経由で IRQ として配信される）
             } else {
                 // 予期しない VM Exit
                 return Ok(HypervisorResult {
@@ -513,22 +747,15 @@ impl Hypervisor {
             return Ok(true);
         }
 
-        // 次のタイマーイベントまでの時間を計算してスリープ
-        let sleep_nanos = self.interrupt_controller.timer.time_until_next_event();
+        // WFI をスキップせずに再実行して、VTIMER_ACTIVATED を待つ
+        // ハードウェア vtimer の発火を検出するために、短いスリープ後に再実行
+        // (ソフトウェアタイマーは使用されていないため time_until_next_event() は None)
 
-        if let Some(nanos) = sleep_nanos {
-            // ナノ秒から Duration に変換
-            let duration = std::time::Duration::from_nanos(nanos);
-            // 最大 10ms までスリープ（応答性のため）
-            let max_sleep = std::time::Duration::from_millis(10);
-            let actual_sleep = duration.min(max_sleep);
-            std::thread::sleep(actual_sleep);
-        } else {
-            // タイマーが設定されていない場合は短いスリープ
-            std::thread::sleep(std::time::Duration::from_micros(100));
-        }
+        // CPU を過度に使用しないよう短いスリープを入れる
+        std::thread::sleep(std::time::Duration::from_micros(100));
 
-        // PC を進める
+        // PC を進めて次の命令へ
+        // 注: Linux はタイマー割り込みがなければすぐに WFI を再実行する
         let pc = self.vcpu.get_reg(Reg::PC)?;
         self.vcpu.set_reg(Reg::PC, pc + 4)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl DebugStats {
 
     fn log_timer_sync(&mut self, guest_ctl: u64, guest_cval: u64, virt_counter: u64) {
         self.timer_sync_count += 1;
-        if self.timer_sync_count <= 20 || self.timer_sync_count % 5000 == 0 {
+        if self.timer_sync_count <= 20 || self.timer_sync_count.is_multiple_of(5000) {
             let enabled = (guest_ctl & 0x1) != 0;
             let imask = (guest_ctl & 0x2) != 0;
             eprintln!(
@@ -81,7 +81,7 @@ impl DebugStats {
 
     fn log_sw_timer_fire(&mut self, hw_counter: u64, cval: u64) {
         self.sw_timer_fire_count += 1;
-        if self.sw_timer_fire_count <= 20 || self.sw_timer_fire_count % 1000 == 0 {
+        if self.sw_timer_fire_count <= 20 || self.sw_timer_fire_count.is_multiple_of(1000) {
             eprintln!(
                 "[SW_TIMER_FIRE #{}] counter=0x{:x} >= cval=0x{:x} -> injecting IRQ via GIC",
                 self.sw_timer_fire_count, hw_counter, cval
@@ -458,7 +458,7 @@ impl Hypervisor {
                             self.debug_stats.wfi_count += 1;
                             let wfi_count = self.debug_stats.wfi_count;
                             let exit_count = self.debug_stats.exit_count;
-                            if wfi_count <= 5 || wfi_count % 10000 == 0 {
+                            if wfi_count <= 5 || wfi_count.is_multiple_of(10000) {
                                 eprintln!("[WFI #{}] at exit #{}", wfi_count, exit_count);
                             }
                         }
@@ -473,7 +473,7 @@ impl Hypervisor {
             }
 
             // 定期的にサマリーを出力
-            if self.debug_stats.exit_count % 5000 == 0 {
+            if self.debug_stats.exit_count.is_multiple_of(5000) {
                 let gic_pending = self.interrupt_controller.has_pending_irq();
                 self.debug_stats.log_exit_summary(
                     post_run_ctl,

--- a/tests/linux_boot_test.rs
+++ b/tests/linux_boot_test.rs
@@ -49,8 +49,8 @@ impl MmioHandler for UartCollector {
             if let Ok(mut output) = self.output.lock() {
                 output.push(byte);
             }
-            // 標準出力にも出力
-            print!("{}", byte as char);
+            // 標準出力にも出力 (inner.write でも出力されるのでスキップ)
+            // print!("{}", byte as char);
         }
         self.inner.write(offset, value, size)
     }


### PR DESCRIPTION
## Summary

- FIQ カーネルパニックを修正: ハードウェア vtimer を完全無効化し、ソフトウェアでタイマーを検出
- vtimer_mask と vtimer_offset を設定してゲストのタイマー動作を正常化
- GIC 経由で VIRT_TIMER_IRQ を注入する方式に変更

## 問題

Linux カーネルが起動時に FIQ (Fast Interrupt Request) を受信し、カーネルパニックが発生していました。

```
[  0.000000] Kernel panic - not syncing: Unexpected FIQ
```

原因は ARM64 Generic Timer のハードウェア vtimer が `vcpu.run()` 中に FIQ を発火させることでした。

## 解決策

ハードウェア vtimer を完全に無効化し、ソフトウェアでタイマー発火を検出して GIC 経由で IRQ を注入する方式に変更しました。

### 主な変更点

1. **vtimer_mask と vtimer_offset の設定** (`src/lib.rs`)
   - `vtimer_mask=true` で FIQ 配信を抑制
   - `vtimer_offset` にハードウェアカウンタ値を設定し、ゲストのカウンタを 0 から開始

2. **ハードウェアタイマーの完全無効化** (`src/lib.rs`)
   - `vcpu.run()` 前に `CTL=0x2` (ENABLE=0, IMASK=1) を強制
   - `CVAL=i64::MAX` を設定して発火を防止

3. **ソフトウェアタイマー発火検出** (`src/lib.rs`)
   - ゲストが設定した CTL/CVAL を読み取りソフトウェアタイマーにコピー
   - ハードウェアカウンタと CVAL を比較して発火条件を検出
   - 発火時は GIC 経由で `VIRT_TIMER_IRQ` (27) を注入

4. **デバッグ情報の追加** (`src/lib.rs`, `src/devices/timer.rs`)
   - タイマー同期、発火検出、統計情報のログ出力

## Test plan

- [x] `cargo test --release` - 全テストパス
- [x] `cargo test --release --test linux_boot_test -- --ignored --nocapture` - FIQ パニックなしで起動
- [x] Linux カーネル v6.6 の起動確認
  - CPU 検出、SMP 初期化、各種サブシステム初期化が正常に進行

## Technical Details

### タイマーアーキテクチャの問題

macOS Hypervisor.framework では、ARM64 の仮想タイマー (vtimer) がゲスト OS に直接 FIQ を配信します。しかし Linux カーネルは EL1 で FIQ ハンドラを持たないため、FIQ を受信するとパニックします。

### 解決アプローチ

```
[従来]
Guest Timer → Hardware vtimer → FIQ → Kernel Panic!

[修正後]
Guest Timer → Software detection → GIC → IRQ → Kernel handles normally
```

1. `vtimer_mask=true` を設定して FIQ 配信を抑制
2. `vcpu.run()` 前にハードウェアタイマーを無効化 (CTL=0x2, CVAL=i64::MAX)
3. `vcpu.run()` 後にゲストの設定を読み取り
4. ハードウェアカウンタと CVAL を比較して発火条件を検出
5. GIC 経由で IRQ を注入

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to detect pending interrupts.

* **Improvements**
  * Calibrated virtual timer frequency for Apple Silicon.
  * Exposed virtual-timer asserted state.
  * Enabled additional default interrupts and adjusted default interrupt priority.

* **Bug Fixes**
  * Masked inactive timers in the device-tree so only the virtual timer is active.

* **Tests**
  * Silenced test console output for certain UART writes; captured output remains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->